### PR TITLE
Relist ideas after project creation

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -10,6 +10,7 @@ import { findMainWorktree, getWorkspaceRoot } from "../utils/workspace.js";
 import { gitAddWorktree, gitCommit, hasUncommittedChanges } from "../utils/git.js";
 import { readGrindConfig } from "../utils/config.js";
 import { parseRepoUrl } from "../utils/repo.js";
+import { listIdeas } from "./list.js";
 
 /**
  * Open editor to get a message from the user
@@ -156,6 +157,10 @@ export async function newProject(
   console.log(`Working directory: ${name}/projects/${name}/`);
   console.log(`Branch: ${name}`);
   console.log(`\nNext: cd ${name}/projects/${name}`);
+
+  // Relist remaining ideas
+  console.log("\nRemaining ideas:");
+  await listIdeas();
 }
 
 /**


### PR DESCRIPTION
## Summary
- After `grind new project` creates a project and removes the source idea, the remaining ideas are now automatically listed so the user can continue triaging without running `grind list ideas` separately.

## Test plan
- [ ] Run `grind new project "test" <idea-number>` and verify remaining ideas are printed after the project creation summary
- [ ] Verify `bun run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)