### PR TITLE
Copy idea into project worktree as the-idea.md

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -148,6 +148,9 @@ export async function newProject(
   console.log(`Creating project worktree: ${name}/`);
   await gitAddWorktree(bareRepoPath, worktreePath, name);
   
+  // Copy the original idea into the project worktree
+  await writeFile(path.join(worktreePath, "the-idea.md"), idea.content, "utf-8");
+
   // Step 3: Delete the idea file from main worktree
   const ideaFilePath = path.join(mainWorktree, "ideas", idea.filename);
   await unlink(ideaFilePath);


### PR DESCRIPTION
## Summary
- After creating the project worktree, the original idea's content is written to `the-idea.md` at the worktree root so it's always available for reference alongside the project code.

## Test plan
- [ ] Run `grind new project "test" <idea-number>` and verify `the-idea.md` exists in the new worktree root with the idea content
- [ ] Verify `bun run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)