### PR TITLE
Fix: grind status always shows 2026-01-25 as Started date (closes #22)

### DIFF
--- a/__mocks__/bun.ts
+++ b/__mocks__/bun.ts
@@ -1,6 +1,9 @@
+const defaultResult = {
+  stdout: Buffer.from(""),
+  exitCode: 0,
+};
+
 export const $ = jest.fn().mockImplementation(() => ({
-  nothrow: jest.fn().mockResolvedValue({
-    stdout: Buffer.from(""),
-    exitCode: 0,
-  }),
+  nothrow: jest.fn().mockResolvedValue(defaultResult),
+  quiet: jest.fn().mockResolvedValue(defaultResult),
 }));

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -87,7 +87,7 @@ export async function getCommitCount(repoPath: string, branch: string): Promise<
  */
 export async function getFirstCommitDate(repoPath: string, branch: string): Promise<string | null> {
   try {
-    const result = await $`git -C ${repoPath} log ${branch} --reverse --format=%aI`.quiet();
+    const result = await $`git -C ${repoPath} log ${branch} --not main --reverse --format=%aI`.quiet();
     const firstLine = result.stdout.toString().trim().split("\n")[0];
     return firstLine || null;
   } catch {

--- a/tests/utils/git.test.ts
+++ b/tests/utils/git.test.ts
@@ -1,0 +1,53 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { getFirstCommitDate } from "../../src/utils/git.ts";
+
+jest.mock("bun");
+
+const mock$ = jest.requireMock("bun").$ as jest.Mock;
+
+describe("getFirstCommitDate", () => {
+  const repoPath = "/fake/repo.git";
+  const branch = "my-project";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mock$.mockImplementation(() => ({
+      quiet: jest.fn().mockResolvedValue({ stdout: Buffer.from("") }),
+    }));
+  });
+
+  it("returns null when no project-specific commits exist", async () => {
+    const result = await getFirstCommitDate(repoPath, branch);
+    expect(result).toBeNull();
+  });
+
+  it("returns the first commit date when project-specific commits exist", async () => {
+    mock$.mockImplementation(() => ({
+      quiet: jest.fn().mockResolvedValue({
+        stdout: Buffer.from("2026-06-01T10:00:00+00:00\n2026-06-02T12:00:00+00:00\n"),
+      }),
+    }));
+
+    const result = await getFirstCommitDate(repoPath, branch);
+    expect(result).toBe("2026-06-01T10:00:00+00:00");
+  });
+
+  it("returns null on git error", async () => {
+    mock$.mockImplementation(() => ({
+      quiet: jest.fn().mockRejectedValue(new Error("git error")),
+    }));
+
+    const result = await getFirstCommitDate(repoPath, branch);
+    expect(result).toBeNull();
+  });
+
+  it("excludes commits already on main when finding the first commit date", async () => {
+    await getFirstCommitDate(repoPath, branch);
+
+    const templateStrings = mock$.mock.calls[0][0] as string[];
+    expect(templateStrings.join("")).toContain("--not main");
+  });
+});


### PR DESCRIPTION
## Summary

- Every project branch inherits the initial commit from `main`, so `git log --reverse` was always returning that commit's date (2026-01-25) as the "Started" date in `grind status`
- Added `--not main` to the `getFirstCommitDate` git log command to exclude commits already on `main`, returning only the first project-specific commit date
- Extended the bun mock to support `.quiet()` (previously only `.nothrow()`) so git utility functions can be unit tested

## Test plan

- [x] Run `bun test` — all 12 tests pass including 4 new tests for `getFirstCommitDate`
- [x] Run `bun run typecheck` — no type errors
- [x] Run `grind status` in a workspace and verify the Started column shows the actual project start date instead of 2026-01-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)