### PR TITLE
Error handling overhaul — replace process.exit(1) with structured error handling

### DIFF
--- a/src/commands/cancel.ts
+++ b/src/commands/cancel.ts
@@ -8,6 +8,7 @@ import { rm } from "node:fs/promises";
 import { requireWorkspace } from "../utils/workspace.js";
 import { fileExists } from "../utils/files.js";
 import { gitCommit } from "../utils/git.js";
+import { GrindUserError, GrindSystemError } from "../utils/errors.js";
 
 /**
  * Cancel (abandon) a project
@@ -23,16 +24,16 @@ export async function cancelProject(
   // 2. Verify project worktree exists
   const worktreePath = path.join(workspaceRoot, projectName);
   if (!(await fileExists(worktreePath))) {
-    console.error(`Error: Project worktree '${projectName}' does not exist.`);
-    process.exit(1);
+    throw new GrindUserError(`Project worktree '${projectName}' does not exist.`);
   }
 
   // 3. Detect if user is inside the project worktree
   const cwd = process.cwd();
   if (cwd === worktreePath || cwd.startsWith(worktreePath + path.sep)) {
-    console.error(`Error: You are inside this project's worktree.`);
-    console.error(`Please cd to your workspace root first: cd ${workspaceRoot}`);
-    process.exit(1);
+    throw new GrindUserError(
+      `You are inside this project's worktree.\n` +
+      `Please cd to your workspace root first: cd ${workspaceRoot}`
+    );
   }
 
   // 4. Remove the worktree
@@ -45,9 +46,10 @@ export async function cancelProject(
     }
     console.log(`  - Removed worktree: ${projectName}/`);
   } catch {
-    console.error(`Error: Could not remove worktree. It may have uncommitted changes.`);
-    console.error(`Use --force to remove anyway.`);
-    process.exit(1);
+    throw new GrindSystemError(
+      "Could not remove worktree. It may have uncommitted changes.\n" +
+      "Use --force to remove anyway."
+    );
   }
 
   // 5. Delete the branch

--- a/src/commands/clone.ts
+++ b/src/commands/clone.ts
@@ -6,6 +6,7 @@ import { $ } from "bun";
 import path from "node:path";
 import { mkdir } from "node:fs/promises";
 import { fileExists } from "../utils/files.js";
+import { GrindUserError, GrindSystemError } from "../utils/errors.js";
 
 /**
  * Derive a directory name from a git URL
@@ -32,8 +33,7 @@ export async function clone(url: string, directory?: string): Promise<void> {
   const targetDir = path.resolve(dirName);
 
   if (await fileExists(targetDir)) {
-    console.error(`Error: Directory '${dirName}' already exists.`);
-    process.exit(1);
+    throw new GrindUserError(`Directory '${dirName}' already exists.`);
   }
 
   async function cleanup() {
@@ -52,9 +52,8 @@ export async function clone(url: string, directory?: string): Promise<void> {
   try {
     await $`git clone --bare ${url} ${bareRepoPath}`.quiet();
   } catch {
-    console.error("Error: Failed to clone repository. Check that the URL is correct and accessible.");
     await cleanup();
-    process.exit(1);
+    throw new GrindSystemError("Failed to clone repository. Check that the URL is correct and accessible.");
   }
 
   // 3. Fix remote fetch refspec (bare clones use wrong refspec that overwrites local branches)
@@ -67,9 +66,8 @@ export async function clone(url: string, directory?: string): Promise<void> {
   try {
     await $`git -C ${bareRepoPath} rev-parse --verify refs/heads/main`.quiet();
   } catch {
-    console.error("Error: Repository does not have a 'main' branch. Is this a grind workspace?");
     await cleanup();
-    process.exit(1);
+    throw new GrindUserError("Repository does not have a 'main' branch. Is this a grind workspace?");
   }
 
   // 5. Create main worktree (NOT git clone — must be a worktree of the bare repo)
@@ -77,17 +75,15 @@ export async function clone(url: string, directory?: string): Promise<void> {
   try {
     await $`git -C ${bareRepoPath} worktree add ${mainWorktreePath} main`.quiet();
   } catch {
-    console.error("Error: Failed to create main worktree.");
     await cleanup();
-    process.exit(1);
+    throw new GrindSystemError("Failed to create main worktree.");
   }
 
   // 6. Validate this is a grind workspace
   const configPath = path.join(mainWorktreePath, ".grind.json");
   if (!(await fileExists(configPath))) {
-    console.error("Error: Repository does not appear to be a grind workspace (.grind.json not found).");
     await cleanup();
-    process.exit(1);
+    throw new GrindUserError("Repository does not appear to be a grind workspace (.grind.json not found).");
   }
 
   // 7. Restore project worktrees from branches

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -9,6 +9,7 @@ import { fileExists } from "../utils/files.js";
 import { readProjectConfig, writeProjectConfig } from "../utils/config.js";
 import { getCurrentTimestamp } from "../utils/time.js";
 import type { Session } from "../types/index.js";
+import { GrindUserError } from "../utils/errors.js";
 
 /**
  * Open code editor in project's code directory & start work session
@@ -20,32 +21,26 @@ export async function openCode(projectName: string): Promise<void> {
   // Verify project worktree exists
   const worktreePath = path.join(workspaceRoot, projectName);
   if (!(await fileExists(worktreePath))) {
-    console.error(`Error: Project '${projectName}' does not exist.`);
-    process.exit(1);
+    throw new GrindUserError(`Project '${projectName}' does not exist.`);
   }
 
-  // Read project config
   const config = await readProjectConfig(workspaceRoot, projectName);
   if (!config) {
-    console.error(`Error: Could not read .project.json for '${projectName}'.`);
-    process.exit(1);
+    throw new GrindUserError(`Could not read .project.json for '${projectName}'.`);
   }
 
   if (!config.code) {
-    console.error(
-      `Error: No code directory set for '${projectName}'. Run:\n  grind config -p ${projectName} code <directory>`
+    throw new GrindUserError(
+      `No code directory set for '${projectName}'. Run:\n  grind config -p ${projectName} code <directory>`
     );
-    process.exit(1);
   }
 
-  // Resolve code directory path before starting session
   const codeDir = path.isAbsolute(config.code)
     ? config.code
     : path.join(worktreePath, config.code);
 
   if (!(await fileExists(codeDir))) {
-    console.error(`Error: Code directory '${codeDir}' does not exist.`);
-    process.exit(1);
+    throw new GrindUserError(`Code directory '${codeDir}' does not exist.`);
   }
 
   // Check for active session and auto-close with 0 duration if found

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -42,6 +42,7 @@ import { readGrindConfig, writeGrindConfig, readProjectConfig, writeProjectConfi
 import { ROUND_TO_OPTIONS, DEFAULT_PROJECT_TYPES, isValidProjectType } from "../types/index.js";
 import type { RoundTo } from "../types/index.js";
 import { parseRepoUrl } from "../utils/repo.js";
+import { GrindUserError } from "../utils/errors.js";
 
 export interface ConfigOptions {
   global?: boolean;
@@ -117,8 +118,7 @@ async function validateValue(key: string, value: string, isGlobal: boolean, main
       ? grindConfig.projectTypes 
       : DEFAULT_PROJECT_TYPES;
     if (!isValidProjectType(value, validTypes)) {
-      console.error(`Invalid type: ${value}. Valid types: ${validTypes.join(", ")}`);
-      process.exit(1);
+      throw new GrindUserError(`Invalid type: ${value}. Valid types: ${validTypes.join(", ")}`);
     }
     return value;
   }
@@ -126,16 +126,14 @@ async function validateValue(key: string, value: string, isGlobal: boolean, main
   if (key === "projectTypes") {
     const types = value.split(",").map(t => t.trim()).filter(t => t);
     if (!types.length) {
-      console.error(`Invalid projectTypes: ${value}. Must be a comma-separated list of types.`);
-      process.exit(1);
+      throw new GrindUserError(`Invalid projectTypes: ${value}. Must be a comma-separated list of types.`);
     }
     return types;
   }
 
   if (key === "billing.roundTo") {
     if (!ROUND_TO_OPTIONS.includes(value as RoundTo)) {
-      console.error(`Invalid roundTo value: ${value}. Valid options: ${ROUND_TO_OPTIONS.join(", ")}`);
-      process.exit(1);
+      throw new GrindUserError(`Invalid roundTo value: ${value}. Valid options: ${ROUND_TO_OPTIONS.join(", ")}`);
     }
     return value;
   }
@@ -143,29 +141,28 @@ async function validateValue(key: string, value: string, isGlobal: boolean, main
   if (key === "billing.rate" || key === "billing.defaultRate") {
     const num = Number(value);
     if (isNaN(num) || num <= 0) {
-      console.error(`Invalid rate: ${value}. Must be a positive number.`);
-      process.exit(1);
+      throw new GrindUserError(`Invalid rate: ${value}. Must be a positive number.`);
     }
     return num;
   }
 
   if (key === "repo") {
     if (!parseRepoUrl(value)) {
-      console.error(`Invalid repo URL: ${value}`);
-      console.error("Expected a GitHub or GitLab URL, e.g.:");
-      console.error("  git@github.com:owner/repo.git");
-      console.error("  git@gitlab.com:owner/repo.git");
-      console.error("  https://github.com/owner/repo");
-      console.error("  https://gitlab.com/owner/repo");
-      process.exit(1);
+      throw new GrindUserError(
+        `Invalid repo URL: ${value}\n` +
+        "Expected a GitHub or GitLab URL, e.g.:\n" +
+        "  git@github.com:owner/repo.git\n" +
+        "  git@gitlab.com:owner/repo.git\n" +
+        "  https://github.com/owner/repo\n" +
+        "  https://gitlab.com/owner/repo"
+      );
     }
     return value;
   }
 
   if (key === "longTerm") {
     if (value !== "true" && value !== "false") {
-      console.error(`Invalid longTerm value: ${value}. Must be true or false.`);
-      process.exit(1);
+      throw new GrindUserError(`Invalid longTerm value: ${value}. Must be true or false.`);
     }
     return value === "true";
   }
@@ -192,8 +189,7 @@ export async function configList(options: ConfigOptions): Promise<void> {
   } else {
     const config = await readProjectConfig(workspaceRoot, projectName);
     if (!config) {
-      console.error(`Could not read config for project: ${projectName}`);
-      process.exit(1);
+      throw new GrindUserError(`Could not read config for project: ${projectName}`);
     }
 
     // Show type, billing, and client fields
@@ -235,21 +231,18 @@ export async function configGet(key: string, options: ConfigOptions): Promise<vo
     const config = await readGrindConfig(mainWorktree);
     const value = getNestedValue(config as Record<string, any>, key);
     if (value === undefined) {
-      console.error(`Key not found: ${key}`);
-      process.exit(1);
+      throw new GrindUserError(`Key not found: ${key}`);
     }
     console.log(value);
   } else {
     const config = await readProjectConfig(workspaceRoot, projectName);
     if (!config) {
-      console.error(`Could not read config for project: ${projectName}`);
-      process.exit(1);
+      throw new GrindUserError(`Could not read config for project: ${projectName}`);
     }
 
     const value = getNestedValue(config as Record<string, any>, key);
     if (value === undefined) {
-      console.error(`Key not found: ${key}`);
-      process.exit(1);
+      throw new GrindUserError(`Key not found: ${key}`);
     }
     console.log(value);
   }
@@ -268,9 +261,10 @@ export async function configSet(key: string, value: string, options: ConfigOptio
 
   if (useGlobal) {
     if (!GLOBAL_SETTABLE_KEYS.includes(key as typeof GLOBAL_SETTABLE_KEYS[number])) {
-      console.error(`Invalid key for workspace config: ${key}`);
-      console.error(`Valid keys: ${GLOBAL_SETTABLE_KEYS.join(", ")}`);
-      process.exit(1);
+      throw new GrindUserError(
+        `Invalid key for workspace config: ${key}\n` +
+        `Valid keys: ${GLOBAL_SETTABLE_KEYS.join(", ")}`
+      );
     }
 
     const parsed = await validateValue(key, value, true, mainWorktree);
@@ -279,16 +273,16 @@ export async function configSet(key: string, value: string, options: ConfigOptio
     console.log(`${key} = ${parsed}`);
   } else {
     if (!PROJECT_SETTABLE_KEYS.includes(key as typeof PROJECT_SETTABLE_KEYS[number])) {
-      console.error(`Invalid key for project config: ${key}`);
-      console.error(`Valid keys: ${PROJECT_SETTABLE_KEYS.join(", ")}`);
-      process.exit(1);
+      throw new GrindUserError(
+        `Invalid key for project config: ${key}\n` +
+        `Valid keys: ${PROJECT_SETTABLE_KEYS.join(", ")}`
+      );
     }
 
     const parsed = await validateValue(key, value, false, mainWorktree);
     const config = await readProjectConfig(workspaceRoot, projectName);
     if (!config) {
-      console.error(`Could not read config for project: ${projectName}`);
-      process.exit(1);
+      throw new GrindUserError(`Could not read config for project: ${projectName}`);
     }
 
     setNestedValue(config as Record<string, any>, key, parsed);

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { execSync } from "node:child_process";
 import { requireWorkspace } from "../utils/workspace.js";
 import { getIdeaByNumber } from "../utils/files.js";
+import { GrindUserError } from "../utils/errors.js";
 
 /**
  * Open an idea file in $EDITOR
@@ -16,14 +17,12 @@ export async function editIdea(ideaNumber: string): Promise<void> {
 
   const index = parseInt(ideaNumber, 10);
   if (isNaN(index)) {
-    console.error("Error: Idea must be a number from 'grind ideas'");
-    process.exit(1);
+    throw new GrindUserError("Idea must be a number from 'grind ideas'");
   }
 
   const idea = await getIdeaByNumber(index);
   if (!idea) {
-    console.error(`Error: Idea #${index} not found. Run 'grind ideas' to see available ideas.`);
-    process.exit(1);
+    throw new GrindUserError(`Idea #${index} not found. Run 'grind ideas' to see available ideas.`);
   }
 
   const filepath = path.join(mainWorktree, "ideas", idea.filename);

--- a/src/commands/idea.ts
+++ b/src/commands/idea.ts
@@ -5,6 +5,7 @@
 import path from "node:path";
 import { readFile } from "node:fs/promises";
 import { requireWorkspace } from "../utils/workspace.js";
+import { GrindUserError } from "../utils/errors.js";
 
 export async function showIdea(projectName: string): Promise<void> {
   const { workspaceRoot } = await requireWorkspace();
@@ -15,7 +16,6 @@ export async function showIdea(projectName: string): Promise<void> {
     const content = await readFile(ideaPath, "utf-8");
     console.log(content);
   } catch {
-    console.error(`Error: No idea file found at ${ideaPath}`);
-    process.exit(1);
+    throw new GrindUserError(`No idea file found at ${ideaPath}`);
   }
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -7,6 +7,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import type { GrindConfig } from "../types/index.js";
 import { gitInit, gitInitialCommit, gitAddWorktree, gitCommit } from "../utils/git.js";
 import { fileExists } from "../utils/files.js";
+import { GrindUserError } from "../utils/errors.js";
 
 /**
  * Default workspace configuration
@@ -35,8 +36,7 @@ export async function init(): Promise<void> {
 
   // Check if already initialized
   if (await fileExists(bareRepoPath)) {
-    console.error("Error: Grind workspace already initialized (.grind.repo.git exists)");
-    process.exit(1);
+    throw new GrindUserError("Grind workspace already initialized (.grind.repo.git exists)");
   }
 
   // 1. Create bare repo

--- a/src/commands/invoice.ts
+++ b/src/commands/invoice.ts
@@ -12,6 +12,7 @@ import { gitCommit } from "../utils/git.js";
 import { formatDate } from "../utils/time.js";
 import type { ProjectConfig, GrindConfig } from "../types/index.js";
 import PDFDocument from "pdfkit";
+import { GrindUserError } from "../utils/errors.js";
 
 /**
  * Generate invoice for a project
@@ -51,8 +52,7 @@ export async function invoiceProject(projectName: string): Promise<void> {
     configPath = mainWorktreeConfigPath;
     console.log(`Reading config from main worktree (project worktree not found)...`);
   } else {
-    console.error(`Error: Project '${projectName}' not found.`);
-    process.exit(1);
+    throw new GrindUserError(`Project '${projectName}' not found.`);
   }
   
   // 4. Load project config
@@ -66,7 +66,7 @@ export async function invoiceProject(projectName: string): Promise<void> {
   
   if (unbilledSessions.length === 0) {
     console.log("No unbilled sessions found.");
-    process.exit(0);
+    return;
   }
   
   console.log(`\nFound ${unbilledSessions.length} unbilled session(s):`);

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -15,6 +15,7 @@ import { gitAddWorktree, gitCommit, hasUncommittedChanges } from "../utils/git.j
 import { readGrindConfig } from "../utils/config.js";
 import { parseRepoUrl } from "../utils/repo.js";
 import { listIdeas } from "./list.js";
+import { GrindUserError } from "../utils/errors.js";
 
 /**
  * Open editor to get a message from the user
@@ -90,22 +91,17 @@ export async function newProject(
 
   // Check for uncommitted changes FIRST - fail fast
   if (await hasUncommittedChanges(mainWorktree)) {
-    console.error("Error: You have uncommitted changes in grind/. Please commit them first.");
-    process.exit(1);
+    throw new GrindUserError("You have uncommitted changes in grind/. Please commit them first.");
   }
   
-  // Parse idea number
   const ideaIndex = parseInt(ideaNumber, 10);
   if (isNaN(ideaIndex)) {
-    console.error("Error: Idea must be a number from 'grind list ideas'");
-    process.exit(1);
+    throw new GrindUserError("Idea must be a number from 'grind list ideas'");
   }
   
-  // Get idea content
   const idea = await getIdeaByNumber(ideaIndex);
   if (!idea) {
-    console.error(`Error: Idea #${ideaIndex} not found. Run 'grind list ideas' to see available ideas.`);
-    process.exit(1);
+    throw new GrindUserError(`Idea #${ideaIndex} not found. Run 'grind list ideas' to see available ideas.`);
   }
   
   // Read workspace config
@@ -116,8 +112,7 @@ export async function newProject(
   
   // Check if worktree directory already exists
   if (await fileExists(worktreePath)) {
-    console.error(`Error: Directory '${name}' already exists.`);
-    process.exit(1);
+    throw new GrindUserError(`Directory '${name}' already exists.`);
   }
   
   // Step 1: Create .project.json in main worktree's projects/ folder
@@ -174,8 +169,7 @@ export async function newIssue(
   if (!message) {
     message = await getMessageFromEditor("Enter issue title above") ?? undefined;
     if (!message) {
-      console.error("Aborted: no message provided.");
-      process.exit(1);
+      throw new GrindUserError("Aborted: no message provided.");
     }
   }
   await newRepoIssue(projectName, message, "ISSUE");
@@ -193,8 +187,7 @@ export async function newFeature(
   if (!message) {
     message = await getMessageFromEditor("Enter feature title above") ?? undefined;
     if (!message) {
-      console.error("Aborted: no message provided.");
-      process.exit(1);
+      throw new GrindUserError("Aborted: no message provided.");
     }
   }
   await newRepoIssue(projectName, message, "FEATURE");
@@ -214,23 +207,24 @@ async function newRepoIssue(
     const content = await readFile(configPath, "utf-8");
     projectConfig = JSON.parse(content);
   } catch {
-    console.error(`Error: Project '${projectName}' not found.`);
-    process.exit(1);
+    throw new GrindUserError(`Project '${projectName}' not found.`);
   }
   if (!projectConfig.repo) {
-    console.error(`Error: No 'repo' configured for project '${projectName}'.`);
-    console.error(`Set it with: grind config -p ${projectName} repo git@github.com:owner/repo.git`);
-    process.exit(1);
+    throw new GrindUserError(
+      `No 'repo' configured for project '${projectName}'.\n` +
+      `Set it with: grind config -p ${projectName} repo git@github.com:owner/repo.git`
+    );
   }
 
   const repoInfo = parseRepoUrl(projectConfig.repo);
   if (!repoInfo) {
-    console.error(`Error: Unrecognized repo URL: ${projectConfig.repo}`);
-    console.error("Expected GitHub or GitLab URL, e.g.:");
-    console.error("  git@github.com:owner/repo.git");
-    console.error("  git@gitlab.com:owner/repo.git");
-    console.error("  https://github.com/owner/repo");
-    process.exit(1);
+    throw new GrindUserError(
+      `Unrecognized repo URL: ${projectConfig.repo}\n` +
+      "Expected GitHub or GitLab URL, e.g.:\n" +
+      "  git@github.com:owner/repo.git\n" +
+      "  git@gitlab.com:owner/repo.git\n" +
+      "  https://github.com/owner/repo"
+    );
   }
 
   const title = `[${prefix}]: ${message}`;

--- a/src/commands/promote.ts
+++ b/src/commands/promote.ts
@@ -8,6 +8,7 @@ import { $ } from "bun";
 import { requireWorkspace } from "../utils/workspace.js";
 import { fileExists } from "../utils/files.js";
 import type { ProjectConfig } from "../types/index.js";
+import { GrindUserError, GrindSystemError } from "../utils/errors.js";
 
 const N8N_WEBHOOK_URL = "https://gandalf.local:5678/webhook-test/promote";
 
@@ -36,16 +37,14 @@ export async function promoteProject(projectName: string): Promise<void> {
   } else if (await fileExists(mainWorktreeConfigPath)) {
     configPath = mainWorktreeConfigPath;
   } else {
-    console.error(`Error: Project '${projectName}' not found.`);
-    process.exit(1);
+    throw new GrindUserError(`Project '${projectName}' not found.`);
   }
 
   const configContent = await readFile(configPath, "utf-8");
   const config: ProjectConfig = JSON.parse(configContent);
 
   if (!config.publications || config.publications.length === 0) {
-    console.error(`Error: Project '${projectName}' has no publication URLs.`);
-    process.exit(1);
+    throw new GrindUserError(`Project '${projectName}' has no publication URLs.`);
   }
 
   const publicationUrl = config.publications[0].url;
@@ -63,14 +62,12 @@ export async function promoteProject(projectName: string): Promise<void> {
   const responseBody = lines.join("\n");
 
   if (exitCode !== 0) {
-    console.error("Error: Could not reach n8n server.");
-    process.exit(1);
+    throw new GrindSystemError("Could not reach n8n server.");
   }
 
   const httpStatus = parseInt(statusCode || "0", 10);
   if (httpStatus < 200 || httpStatus >= 300) {
-    console.error(`Error: n8n webhook failed: ${responseBody || `HTTP ${httpStatus}`}`);
-    process.exit(1);
+    throw new GrindSystemError(`n8n webhook failed: ${responseBody || `HTTP ${httpStatus}`}`);
   }
 
   console.log("\nn8n response:");

--- a/src/commands/publish-project.ts
+++ b/src/commands/publish-project.ts
@@ -9,6 +9,7 @@ import { fileExists } from "../utils/files.js";
 import { hasUncommittedChanges } from "../utils/git.js";
 import { readProjectConfig, writeProjectConfig } from "../utils/config.js";
 import { getCurrentTimestamp } from "../utils/time.js";
+import { GrindUserError, GrindSystemError } from "../utils/errors.js";
 
 /**
  * Publish a project by merging to main
@@ -24,26 +25,22 @@ export async function publishProject(
   // 2. Verify project worktree exists
   const worktreePath = path.join(workspaceRoot, projectName);
   if (!(await fileExists(worktreePath))) {
-    console.error(`Error: Project worktree '${projectName}' does not exist.`);
-    process.exit(1);
+    throw new GrindUserError(`Project worktree '${projectName}' does not exist.`);
   }
 
   // 3. Check for uncommitted changes in both worktrees
   if (await hasUncommittedChanges(mainWorktree)) {
-    console.error("Error: Main worktree has uncommitted changes. Please commit or stash them first.");
-    process.exit(1);
+    throw new GrindUserError("Main worktree has uncommitted changes. Please commit or stash them first.");
   }
   if (await hasUncommittedChanges(worktreePath)) {
-    console.error(`Error: Project '${projectName}' has uncommitted changes. Please commit or stash them first.`);
-    process.exit(1);
+    throw new GrindUserError(`Project '${projectName}' has uncommitted changes. Please commit or stash them first.`);
   }
 
   // 4. If a URL was provided, record the publication in .project.json and commit
   if (options?.url) {
     const config = await readProjectConfig(workspaceRoot, projectName);
     if (!config) {
-      console.error(`Error: Could not read .project.json for project '${projectName}'.`);
-      process.exit(1);
+      throw new GrindUserError(`Could not read .project.json for project '${projectName}'.`);
     }
 
     config.publications = config.publications ?? [];
@@ -59,9 +56,8 @@ export async function publishProject(
   // 5. Switch to main branch in grind/ worktree
   try {
     await $`git -C ${mainWorktree} switch main`.quiet();
-  } catch (error) {
-    console.error("Error: Could not switch to main branch. Is it checked out in another worktree?");
-    process.exit(1);
+  } catch {
+    throw new GrindSystemError("Could not switch to main branch. Is it checked out in another worktree?");
   }
 
   // 6. Merge project branch into main
@@ -71,9 +67,8 @@ export async function publishProject(
   try {
     await $`git -C ${mainWorktree} merge ${projectName}`.quiet();
     console.log("Merge completed successfully.");
-  } catch (error) {
-    console.error(`Error: Merge failed. Please resolve conflicts manually in ${mainWorktree}`);
-    process.exit(1);
+  } catch {
+    throw new GrindSystemError(`Merge failed. Please resolve conflicts manually in ${mainWorktree}`);
   }
 
   // 7. If -d or -D flag: remove worktree (and optionally branch)

--- a/src/commands/reject.ts
+++ b/src/commands/reject.ts
@@ -7,6 +7,7 @@ import { rename } from "node:fs/promises";
 import { requireWorkspace } from "../utils/workspace.js";
 import { getIdeaByNumber } from "../utils/files.js";
 import { gitCommit } from "../utils/git.js";
+import { GrindUserError } from "../utils/errors.js";
 
 /**
  * Reject an idea by prepending "rejected-" to filename
@@ -18,21 +19,16 @@ export async function rejectIdea(ideaNumber: string): Promise<void> {
   // Parse idea number
   const ideaIndex = parseInt(ideaNumber, 10);
   if (isNaN(ideaIndex)) {
-    console.error("Error: Idea must be a number from 'grind list ideas'");
-    process.exit(1);
+    throw new GrindUserError("Idea must be a number from 'grind list ideas'");
   }
 
-  // Get idea by number (non-rejected only)
   const idea = await getIdeaByNumber(ideaIndex, false);
   if (!idea) {
-    console.error(`Error: Idea #${ideaIndex} not found. Run 'grind list ideas' to see available ideas.`);
-    process.exit(1);
+    throw new GrindUserError(`Idea #${ideaIndex} not found. Run 'grind list ideas' to see available ideas.`);
   }
 
-  // Check if already rejected (shouldn't happen, but safety check)
   if (idea.filename.startsWith("rejected-")) {
-    console.error(`Error: Idea #${ideaIndex} is already rejected.`);
-    process.exit(1);
+    throw new GrindUserError(`Idea #${ideaIndex} is already rejected.`);
   }
 
   // Create new filename with "rejected-" prefix

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -7,6 +7,7 @@ import { requireWorkspace } from "../utils/workspace.js";
 import { readProjectConfig, writeProjectConfig } from "../utils/config.js";
 import { getCurrentTimestamp, calculateDuration, roundTimeByStrategy } from "../utils/time.js";
 import { gitCommit, gitCommitInteractive, hasUncommittedChanges } from "../utils/git.js";
+import { GrindUserError } from "../utils/errors.js";
 
 /**
  * Save work on a project
@@ -38,8 +39,7 @@ export async function save(projectName: string, options?: { quiet?: boolean }): 
   // Read project config
   const config = await readProjectConfig(workspaceRoot, projectName);
   if (!config) {
-    console.error(`Error: Could not read .project.json for '${projectName}'.`);
-    process.exit(1);
+    throw new GrindUserError(`Could not read .project.json for '${projectName}'.`);
   }
 
   // Find and stop active session (if any)

--- a/src/commands/work.ts
+++ b/src/commands/work.ts
@@ -9,6 +9,7 @@ import { fileExists } from "../utils/files.js";
 import { readProjectConfig, writeProjectConfig } from "../utils/config.js";
 import { getCurrentTimestamp } from "../utils/time.js";
 import type { Session } from "../types/index.js";
+import { GrindUserError } from "../utils/errors.js";
 
 /**
  * Start working on a project
@@ -20,16 +21,13 @@ export async function workStart(projectName: string, options?: { quiet?: boolean
   // Verify project worktree exists
   const worktreePath = path.join(workspaceRoot, projectName);
   if (!(await fileExists(worktreePath))) {
-    console.error(`Error: Project '${projectName}' does not exist.`);
-    process.exit(1);
+    throw new GrindUserError(`Project '${projectName}' does not exist.`);
   }
 
   if (!options?.quiet) {
-    // Read project config
     const config = await readProjectConfig(workspaceRoot, projectName);
     if (!config) {
-      console.error(`Error: Could not read .project.json for '${projectName}'.`);
-      process.exit(1);
+      throw new GrindUserError(`Could not read .project.json for '${projectName}'.`);
     }
 
     // Check for active session - keep it open if exists (orphaned session)

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import { Command } from "commander";
+import { GrindError } from "./utils/errors.js";
 import {
   DEFAULT_PROJECT_TYPES,
   isValidProjectType,
@@ -146,10 +147,10 @@ newCmd
       const grindConfig = await readGrindConfig(mainWorktree);
       const validTypes = getEffectiveProjectTypes(grindConfig);
       if (options.type && !isValidProjectType(options.type, validTypes)) {
-        console.error(
+        throw new GrindError(
           `Invalid type: ${options.type}. Valid types: ${validTypes.join(", ")}`,
+          1,
         );
-        process.exit(1);
       }
       await newProject(name, ideaNumber, {
         type: options.type as ProjectType | undefined,
@@ -347,4 +348,18 @@ program
     await showIdea(project);
   });
 
-program.parse();
+try {
+  await program.parseAsync();
+} catch (error) {
+  if (error instanceof GrindError) {
+    console.error(`Error: ${error.message}`);
+    process.exit(error.exitCode);
+  } else if (error instanceof Error) {
+    console.error(`Unexpected error: ${error.message}`);
+    console.error(error.stack);
+    process.exit(99);
+  } else {
+    console.error("Unexpected error:", error);
+    process.exit(99);
+  }
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+export class GrindError extends Error {
+  exitCode: number;
+  cause?: Error;
+
+  constructor(message: string, exitCode: number = 1, cause?: Error) {
+    super(message);
+    this.name = "GrindError";
+    this.exitCode = exitCode;
+    this.cause = cause;
+  }
+}
+
+export class GrindUserError extends GrindError {
+  constructor(message: string, cause?: Error) {
+    super(message, 1, cause);
+    this.name = "GrindUserError";
+  }
+}
+
+export class GrindSystemError extends GrindError {
+  constructor(message: string, cause?: Error) {
+    super(message, 2, cause);
+    this.name = "GrindSystemError";
+  }
+}

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -4,6 +4,7 @@
 
 import path from "node:path";
 import { fileExists } from "./files.js";
+import { GrindUserError } from "./errors.js";
 
 /**
  * Derive the current project name from the working directory.
@@ -90,14 +91,12 @@ export async function requireWorkspace(): Promise<{
 }> {
   const workspaceRoot = await getWorkspaceRoot(process.cwd());
   if (!workspaceRoot) {
-    console.error("Error: Not in a grind workspace.");
-    process.exit(1);
+    throw new GrindUserError("Not in a grind workspace.");
   }
 
   const mainWorktree = await findMainWorktree(process.cwd());
   if (!mainWorktree) {
-    console.error("Error: Could not find main worktree.");
-    process.exit(1);
+    throw new GrindUserError("Could not find main worktree.");
   }
 
   const bareRepo = path.join(workspaceRoot, BARE_REPO_NAME);

--- a/tests/commands/promote.test.ts
+++ b/tests/commands/promote.test.ts
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import { promoteProject } from "../../src/commands/promote.js";
+import { GrindSystemError } from "../../src/utils/errors.js";
 import * as fs from "node:fs/promises";
 
 jest.mock("node:fs/promises");
@@ -54,7 +55,7 @@ describe("promoteProject", () => {
     expect(mock$).toHaveBeenCalledTimes(1);
   });
 
-  it("should exit with error when curl fails", async () => {
+  it("should throw GrindSystemError when curl fails", async () => {
     mock$.mockImplementation(() => ({
       nothrow: jest.fn().mockResolvedValue({
         stdout: Buffer.from(""),
@@ -64,13 +65,12 @@ describe("promoteProject", () => {
 
     (fs.readFile as jest.Mock).mockResolvedValue(JSON.stringify(baseProjectConfig));
 
-    await promoteProject(projectName);
-
-    expect(console.error).toHaveBeenCalledWith("Error: Could not reach n8n server.");
-    expect(process.exit).toHaveBeenCalledWith(1);
+    const promise = promoteProject(projectName);
+    await expect(promise).rejects.toThrow(GrindSystemError);
+    await expect(promise).rejects.toThrow("Could not reach n8n server.");
   });
 
-  it("should exit with error when n8n returns non-ok response", async () => {
+  it("should throw GrindSystemError when n8n returns non-ok response", async () => {
     mock$.mockImplementation(() => ({
       nothrow: jest.fn().mockResolvedValue({
         stdout: Buffer.from("error occurred\n500"),
@@ -80,9 +80,8 @@ describe("promoteProject", () => {
 
     (fs.readFile as jest.Mock).mockResolvedValue(JSON.stringify(baseProjectConfig));
 
-    await promoteProject(projectName);
-
-    expect(console.error).toHaveBeenCalledWith("Error: n8n webhook failed: error occurred");
-    expect(process.exit).toHaveBeenCalledWith(1);
+    const promise = promoteProject(projectName);
+    await expect(promise).rejects.toThrow(GrindSystemError);
+    await expect(promise).rejects.toThrow("n8n webhook failed: error occurred");
   });
 });


### PR DESCRIPTION
## Summary

Replaces every `console.error(...); process.exit(1)` across the codebase with structured exception-based error handling. `process.exit` is now called exactly once — in the top-level try/catch handler in `src/index.ts`.

## Changes

- **New:** `src/utils/errors.ts` — `GrindError` (base), `GrindUserError` (exit 1), `GrindSystemError` (exit 2), each with `message`, `exitCode`, and optional `cause`
- **Modified:** `src/index.ts` — `program.parse()` wrapped in try/catch; catches GrindError (prints message + exits with code) and unexpected errors (prints stack + exits 99)
- **Modified:** `src/utils/workspace.ts` — `requireWorkspace()` throws `GrindUserError` instead of `process.exit(1)`
- **Modified:** 14 command files — all `console.error(...); process.exit(1)` migrated to throws. System/git/network failures use `GrindSystemError`; bad input/validation use `GrindUserError`
- **Modified:** `tests/commands/promote.test.ts` — updated to expect thrown errors instead of mocked `process.exit`

Closes #25