### PR TITLE
Shared path resolution utilities

### DIFF
--- a/src/commands/cancel.ts
+++ b/src/commands/cancel.ts
@@ -9,6 +9,7 @@ import { requireWorkspace } from "../utils/workspace.js";
 import { fileExists } from "../utils/files.js";
 import { gitCommit } from "../utils/git.js";
 import { GrindUserError, GrindSystemError } from "../utils/errors.js";
+import { getProjectWorktreePath, getProjectConfigDirPath } from "../utils/paths.js";
 
 /**
  * Cancel (abandon) a project
@@ -22,7 +23,7 @@ export async function cancelProject(
   const { workspaceRoot, mainWorktree, bareRepo } = await requireWorkspace();
 
   // 2. Verify project worktree exists
-  const worktreePath = path.join(workspaceRoot, projectName);
+  const worktreePath = getProjectWorktreePath(workspaceRoot, projectName);
   if (!(await fileExists(worktreePath))) {
     throw new GrindUserError(`Project worktree '${projectName}' does not exist.`);
   }
@@ -61,7 +62,7 @@ export async function cancelProject(
   }
 
   // 6. Delete project config from main worktree
-  const projectConfigDir = path.join(mainWorktree, "projects", projectName);
+  const projectConfigDir = getProjectConfigDirPath(mainWorktree, projectName);
   if (await fileExists(projectConfigDir)) {
     await rm(projectConfigDir, { recursive: true });
     await gitCommit(mainWorktree, `Cancel project: ${projectName}`);

--- a/src/commands/clone.ts
+++ b/src/commands/clone.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { mkdir } from "node:fs/promises";
 import { fileExists } from "../utils/files.js";
 import { GrindUserError, GrindSystemError } from "../utils/errors.js";
+import { getBareRepoPath, getMainWorktreePath, getGrindConfigPath, getProjectWorktreePath } from "../utils/paths.js";
 
 /**
  * Derive a directory name from a git URL
@@ -40,8 +41,8 @@ export async function clone(url: string, directory?: string): Promise<void> {
     try { await $`rm -rf ${targetDir}`.quiet(); } catch {}
   }
 
-  const bareRepoPath = path.join(targetDir, ".grind.repo.git");
-  const mainWorktreePath = path.join(targetDir, "grind");
+  const bareRepoPath = getBareRepoPath(targetDir);
+  const mainWorktreePath = getMainWorktreePath(targetDir);
 
   // 1. Create target directory
   console.log(`Creating workspace directory: ${dirName}/`);
@@ -80,7 +81,7 @@ export async function clone(url: string, directory?: string): Promise<void> {
   }
 
   // 6. Validate this is a grind workspace
-  const configPath = path.join(mainWorktreePath, ".grind.json");
+  const configPath = getGrindConfigPath(mainWorktreePath);
   if (!(await fileExists(configPath))) {
     await cleanup();
     throw new GrindUserError("Repository does not appear to be a grind workspace (.grind.json not found).");
@@ -93,7 +94,7 @@ export async function clone(url: string, directory?: string): Promise<void> {
   if (branches.length > 0) {
     console.log(`\nRestoring ${branches.length} project worktree(s)...`);
     for (const branch of branches) {
-      const worktreePath = path.join(targetDir, branch);
+      const worktreePath = getProjectWorktreePath(targetDir, branch);
       try {
         await $`git -C ${bareRepoPath} worktree add ${worktreePath} ${branch}`.quiet();
         console.log(`  - ${branch}/`);

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -10,6 +10,7 @@ import { readProjectConfig, writeProjectConfig } from "../utils/config.js";
 import { getCurrentTimestamp } from "../utils/time.js";
 import type { Session } from "../types/index.js";
 import { GrindUserError } from "../utils/errors.js";
+import { getProjectWorktreePath } from "../utils/paths.js";
 
 /**
  * Open code editor in project's code directory & start work session
@@ -19,7 +20,7 @@ export async function openCode(projectName: string): Promise<void> {
   const { workspaceRoot } = await requireWorkspace();
 
   // Verify project worktree exists
-  const worktreePath = path.join(workspaceRoot, projectName);
+  const worktreePath = getProjectWorktreePath(workspaceRoot, projectName);
   if (!(await fileExists(worktreePath))) {
     throw new GrindUserError(`Project '${projectName}' does not exist.`);
   }

--- a/src/commands/idea.ts
+++ b/src/commands/idea.ts
@@ -2,15 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import path from "node:path";
 import { readFile } from "node:fs/promises";
 import { requireWorkspace } from "../utils/workspace.js";
 import { GrindUserError } from "../utils/errors.js";
+import { getProjectIdeaPath } from "../utils/paths.js";
 
 export async function showIdea(projectName: string): Promise<void> {
   const { workspaceRoot } = await requireWorkspace();
 
-  const ideaPath = path.join(workspaceRoot, projectName, "projects", projectName, "the-idea.md");
+  const ideaPath = getProjectIdeaPath(workspaceRoot, projectName);
 
   try {
     const content = await readFile(ideaPath, "utf-8");

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,12 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import path from "node:path";
 import { mkdir, writeFile } from "node:fs/promises";
 import type { GrindConfig } from "../types/index.js";
 import { gitInit, gitInitialCommit, gitAddWorktree, gitCommit } from "../utils/git.js";
 import { fileExists } from "../utils/files.js";
 import { GrindUserError } from "../utils/errors.js";
+import { getBareRepoPath, getMainWorktreePath, getIdeasDirPath, getProjectsDirPath, getGrindConfigPath } from "../utils/paths.js";
 
 /**
  * Default workspace configuration
@@ -31,8 +31,8 @@ export const DEFAULT_GRIND_CONFIG: GrindConfig = {
  */
 export async function init(): Promise<void> {
   const cwd = process.cwd();
-  const bareRepoPath = path.join(cwd, ".grind.repo.git");
-  const mainWorktreePath = path.join(cwd, "grind");
+  const bareRepoPath = getBareRepoPath(cwd);
+  const mainWorktreePath = getMainWorktreePath(cwd);
 
   // Check if already initialized
   if (await fileExists(bareRepoPath)) {
@@ -53,10 +53,10 @@ export async function init(): Promise<void> {
 
   // 4. Create structure in main worktree
   console.log("Setting up workspace structure...");
-  await mkdir(path.join(mainWorktreePath, "ideas"), { recursive: true });
-  await mkdir(path.join(mainWorktreePath, "projects"), { recursive: true });
+  await mkdir(getIdeasDirPath(mainWorktreePath), { recursive: true });
+  await mkdir(getProjectsDirPath(mainWorktreePath), { recursive: true });
   await writeFile(
-    path.join(mainWorktreePath, ".grind.json"),
+    getGrindConfigPath(mainWorktreePath),
     JSON.stringify(DEFAULT_GRIND_CONFIG, null, 2),
     "utf-8"
   );

--- a/src/commands/invoice.ts
+++ b/src/commands/invoice.ts
@@ -13,6 +13,7 @@ import { formatDate } from "../utils/time.js";
 import type { ProjectConfig, GrindConfig } from "../types/index.js";
 import PDFDocument from "pdfkit";
 import { GrindUserError } from "../utils/errors.js";
+import { getProjectWorktreePath, getProjectConfigPath, getMainProjectConfigPath, getInvoiceDirPath } from "../utils/paths.js";
 
 /**
  * Generate invoice for a project
@@ -28,20 +29,9 @@ export async function invoiceProject(projectName: string): Promise<void> {
   const grindConfig = await readGrindConfig(mainWorktree);
 
   // 3. Determine where to read .project.json from (ONE location only!)
-  const projectWorktreePath = path.join(workspaceRoot, projectName);
-  const projectWorktreeConfigPath = path.join(
-    projectWorktreePath,
-    "projects",
-    projectName,
-    ".project.json"
-  );
-  
-  const mainWorktreeConfigPath = path.join(
-    mainWorktree,
-    "projects",
-    projectName,
-    ".project.json"
-  );
+  const projectWorktreePath = getProjectWorktreePath(workspaceRoot, projectName);
+  const projectWorktreeConfigPath = getProjectConfigPath(workspaceRoot, projectName);
+  const mainWorktreeConfigPath = getMainProjectConfigPath(mainWorktree, projectName);
   
   let configPath: string;
 
@@ -192,13 +182,7 @@ ${tableRows}
   });
 
   // 9. All content generated successfully - now write everything atomically
-  const invoiceDir = path.join(
-    mainWorktree,
-    "projects",
-    projectName,
-    "invoices",
-    timestamp
-  );
+  const invoiceDir = getInvoiceDirPath(mainWorktree, projectName, timestamp);
   const markdownPath = path.join(invoiceDir, "invoice.md");
   const pdfPath = path.join(invoiceDir, "invoice.pdf");
 

--- a/src/commands/journal.ts
+++ b/src/commands/journal.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { mkdir } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { requireWorkspace } from "../utils/workspace.js";
+import { getJournalDirPath } from "../utils/paths.js";
 
 /**
  * Open today's journal entry in nvim
@@ -14,7 +15,7 @@ import { requireWorkspace } from "../utils/workspace.js";
 export async function journal(): Promise<void> {
   const { mainWorktree } = await requireWorkspace();
 
-  const journalDir = path.join(mainWorktree, "journal");
+  const journalDir = getJournalDirPath(mainWorktree);
   await mkdir(journalDir, { recursive: true });
 
   const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -9,6 +9,7 @@ import { getActiveWorktrees } from "../utils/git.js";
 import { DIM, RED, RESET } from "../utils/colors.js";
 import type { ProjectConfig } from "../types/index.js";
 import { timeAgo } from "../utils/time.js";
+import { getIdeasDirPath, getProjectConfigPath } from "../utils/paths.js";
 
 /**
  * List all idea files for triage
@@ -20,7 +21,7 @@ export async function listIdeas(options?: {
 }): Promise<void> {
   const { mainWorktree } = await requireWorkspace();
 
-  const ideasDir = path.join(mainWorktree, "ideas");
+  const ideasDir = getIdeasDirPath(mainWorktree);
 
   // Get all files, sorted by filename (chronological)
   let files = await readdir(ideasDir);
@@ -73,7 +74,7 @@ export async function listProjects(): Promise<void> {
   // Load .project.json from each project's own worktree (has latest session data)
   const projects: { config: ProjectConfig; dir: string }[] = [];
   for (const name of worktreeNames) {
-    const configPath = path.join(workspaceRoot, name, "projects", name, ".project.json");
+    const configPath = getProjectConfigPath(workspaceRoot, name);
     try {
       const content = await readFile(configPath, "utf-8");
       projects.push({ config: JSON.parse(content), dir: name });

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -16,6 +16,7 @@ import { readGrindConfig } from "../utils/config.js";
 import { parseRepoUrl } from "../utils/repo.js";
 import { listIdeas } from "./list.js";
 import { GrindUserError } from "../utils/errors.js";
+import { getIdeasDirPath, getBareRepoPath, getProjectWorktreePath, getProjectConfigDirPath, getProjectConfigPath } from "../utils/paths.js";
 
 /**
  * Open editor to get a message from the user
@@ -48,7 +49,7 @@ export async function newIdea(
 ): Promise<void> {
   const { mainWorktree } = await requireWorkspace();
 
-  const ideasDir = path.join(mainWorktree, "ideas");
+  const ideasDir = getIdeasDirPath(mainWorktree);
   await mkdir(ideasDir, { recursive: true });
 
   let fileContent: string;
@@ -107,8 +108,8 @@ export async function newProject(
   // Read workspace config
   const grindConfig = await readGrindConfig(mainWorktree);
 
-  const bareRepoPath = path.join(workspaceRoot, ".grind.repo.git");
-  const worktreePath = path.join(workspaceRoot, name);
+  const bareRepoPath = getBareRepoPath(workspaceRoot);
+  const worktreePath = getProjectWorktreePath(workspaceRoot, name);
   
   // Check if worktree directory already exists
   if (await fileExists(worktreePath)) {
@@ -117,7 +118,7 @@ export async function newProject(
   
   // Step 1: Create .project.json in main worktree's projects/ folder
   console.log(`Creating project in grind/projects/${name}/...`);
-  const projectFolderInMain = path.join(mainWorktree, "projects", name);
+  const projectFolderInMain = getProjectConfigDirPath(mainWorktree, name);
   await mkdir(projectFolderInMain, { recursive: true });
   
   const projectConfig: ProjectConfig = {
@@ -200,8 +201,7 @@ async function newRepoIssue(
 ): Promise<void> {
   const { workspaceRoot } = await requireWorkspace();
 
-  // Read project config from project worktree ({workspace}/{project}/projects/{project}/.project.json)
-  const configPath = path.join(workspaceRoot, projectName, "projects", projectName, ".project.json");
+  const configPath = getProjectConfigPath(workspaceRoot, projectName);
   let projectConfig: ProjectConfig;
   try {
     const content = await readFile(configPath, "utf-8");

--- a/src/commands/promote.ts
+++ b/src/commands/promote.ts
@@ -2,33 +2,21 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import path from "node:path";
 import { readFile } from "node:fs/promises";
 import { $ } from "bun";
 import { requireWorkspace } from "../utils/workspace.js";
 import { fileExists } from "../utils/files.js";
 import type { ProjectConfig } from "../types/index.js";
 import { GrindUserError, GrindSystemError } from "../utils/errors.js";
+import { getProjectConfigPath, getMainProjectConfigPath } from "../utils/paths.js";
 
 const N8N_WEBHOOK_URL = "https://gandalf.local:5678/webhook-test/promote";
 
 export async function promoteProject(projectName: string): Promise<void> {
   const { workspaceRoot, mainWorktree } = await requireWorkspace();
 
-  const projectWorktreeConfigPath = path.join(
-    workspaceRoot,
-    projectName,
-    "projects",
-    projectName,
-    ".project.json",
-  );
-
-  const mainWorktreeConfigPath = path.join(
-    mainWorktree,
-    "projects",
-    projectName,
-    ".project.json",
-  );
+  const projectWorktreeConfigPath = getProjectConfigPath(workspaceRoot, projectName);
+  const mainWorktreeConfigPath = getMainProjectConfigPath(mainWorktree, projectName);
 
   let configPath: string;
 

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { readdir, unlink } from "node:fs/promises";
 import { requireWorkspace } from "../utils/workspace.js";
 import { gitCommit } from "../utils/git.js";
+import { getIdeasDirPath } from "../utils/paths.js";
 
 /**
  * Prune rejected ideas by deleting them
@@ -14,7 +15,7 @@ import { gitCommit } from "../utils/git.js";
 export async function pruneIdeas(): Promise<void> {
   const { mainWorktree } = await requireWorkspace();
 
-  const ideasDir = path.join(mainWorktree, "ideas");
+  const ideasDir = getIdeasDirPath(mainWorktree);
 
   // Get all files
   const files = await readdir(ideasDir);

--- a/src/commands/publish-project.ts
+++ b/src/commands/publish-project.ts
@@ -10,6 +10,7 @@ import { hasUncommittedChanges } from "../utils/git.js";
 import { readProjectConfig, writeProjectConfig } from "../utils/config.js";
 import { getCurrentTimestamp } from "../utils/time.js";
 import { GrindUserError, GrindSystemError } from "../utils/errors.js";
+import { getProjectWorktreePath } from "../utils/paths.js";
 
 /**
  * Publish a project by merging to main
@@ -23,7 +24,7 @@ export async function publishProject(
   const { workspaceRoot, mainWorktree, bareRepo } = await requireWorkspace();
 
   // 2. Verify project worktree exists
-  const worktreePath = path.join(workspaceRoot, projectName);
+  const worktreePath = getProjectWorktreePath(workspaceRoot, projectName);
   if (!(await fileExists(worktreePath))) {
     throw new GrindUserError(`Project worktree '${projectName}' does not exist.`);
   }

--- a/src/commands/reject.ts
+++ b/src/commands/reject.ts
@@ -8,6 +8,7 @@ import { requireWorkspace } from "../utils/workspace.js";
 import { getIdeaByNumber } from "../utils/files.js";
 import { gitCommit } from "../utils/git.js";
 import { GrindUserError } from "../utils/errors.js";
+import { getIdeasDirPath } from "../utils/paths.js";
 
 /**
  * Reject an idea by prepending "rejected-" to filename
@@ -32,7 +33,7 @@ export async function rejectIdea(ideaNumber: string): Promise<void> {
   }
 
   // Create new filename with "rejected-" prefix
-  const ideasDir = path.join(mainWorktree, "ideas");
+  const ideasDir = getIdeasDirPath(mainWorktree);
   const oldPath = path.join(ideasDir, idea.filename);
   const newFilename = `rejected-${idea.filename}`;
   const newPath = path.join(ideasDir, newFilename);

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -8,6 +8,7 @@ import { readProjectConfig, writeProjectConfig } from "../utils/config.js";
 import { getCurrentTimestamp, calculateDuration, roundTimeByStrategy } from "../utils/time.js";
 import { gitCommit, gitCommitInteractive, hasUncommittedChanges } from "../utils/git.js";
 import { GrindUserError } from "../utils/errors.js";
+import { getProjectWorktreePath } from "../utils/paths.js";
 
 /**
  * Save work on a project
@@ -21,7 +22,7 @@ import { GrindUserError } from "../utils/errors.js";
 export async function save(projectName: string, options?: { quiet?: boolean }): Promise<void> {
   const { workspaceRoot } = await requireWorkspace();
 
-  const worktreePath = path.join(workspaceRoot, projectName);
+  const worktreePath = getProjectWorktreePath(workspaceRoot, projectName);
 
   // The 'grind' worktree is the main worktree with no .project.json —
   // just stage and commit, no time tracking or billing.

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -11,6 +11,7 @@ import { timeAgo, formatDate } from "../utils/time.js";
 import { parseRepoUrl } from "../utils/repo.js";
 import { DIM, RED, GREEN, RESET } from "../utils/colors.js";
 import type { ProjectConfig } from "../types/index.js";
+import { getProjectConfigPath, getProjectWorktreePath } from "../utils/paths.js";
 
 interface ProjectRow {
   name: string;
@@ -67,7 +68,7 @@ export async function status(): Promise<void> {
   // Load project configs
   const projects: { config: ProjectConfig; name: string; branch: string }[] = [];
   for (const name of worktreeNames) {
-    const configPath = path.join(workspaceRoot, name, "projects", name, ".project.json");
+    const configPath = getProjectConfigPath(workspaceRoot, name);
     try {
       const content = await readFile(configPath, "utf-8");
       projects.push({ config: JSON.parse(content), name, branch: name });
@@ -84,7 +85,7 @@ export async function status(): Promise<void> {
   // Build rows in parallel
   const rowPromises = projects.map(async ({ config, name, branch }): Promise<ProjectRow> => {
     // Git queries
-    const worktreePath = path.join(workspaceRoot, name);
+    const worktreePath = getProjectWorktreePath(workspaceRoot, name);
     const [commitCount, firstCommitDate, lastCommitDate, issueCount, hasChanges] = await Promise.all([
       getCommitCount(bareRepo, branch),
       getFirstCommitDate(bareRepo, branch),

--- a/src/commands/work.ts
+++ b/src/commands/work.ts
@@ -10,6 +10,7 @@ import { readProjectConfig, writeProjectConfig } from "../utils/config.js";
 import { getCurrentTimestamp } from "../utils/time.js";
 import type { Session } from "../types/index.js";
 import { GrindUserError } from "../utils/errors.js";
+import { getProjectWorktreePath, getProjectFilesPath } from "../utils/paths.js";
 
 /**
  * Start working on a project
@@ -19,7 +20,7 @@ export async function workStart(projectName: string, options?: { quiet?: boolean
   const { workspaceRoot } = await requireWorkspace();
 
   // Verify project worktree exists
-  const worktreePath = path.join(workspaceRoot, projectName);
+  const worktreePath = getProjectWorktreePath(workspaceRoot, projectName);
   if (!(await fileExists(worktreePath))) {
     throw new GrindUserError(`Project '${projectName}' does not exist.`);
   }
@@ -55,7 +56,7 @@ export async function workStart(projectName: string, options?: { quiet?: boolean
   }
 
   // Open editor in project directory
-  const projectDir = path.join(worktreePath, "projects", projectName);
+  const projectDir = getProjectFilesPath(workspaceRoot, projectName);
 
   // Spawn editor
   const editorCmd = process.env.EDITOR || process.env.VISUAL || "vi";

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,17 +3,17 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import { readFile, writeFile } from "node:fs/promises";
-import path from "node:path";
 import type { GrindConfig, ProjectConfig } from "../types/index.js";
+import { getGrindConfigPath, getProjectConfigPath } from "./paths.js";
 
 export async function readGrindConfig(rootPath: string): Promise<GrindConfig> {
-  const configPath = path.join(rootPath, ".grind.json");
+  const configPath = getGrindConfigPath(rootPath);
   const content = await readFile(configPath, "utf-8");
   return JSON.parse(content);
 }
 
 export async function writeGrindConfig(rootPath: string, config: GrindConfig): Promise<void> {
-  const configPath = path.join(rootPath, ".grind.json");
+  const configPath = getGrindConfigPath(rootPath);
   await writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
 }
 
@@ -21,14 +21,7 @@ export async function readProjectConfig(
   workspaceRoot: string,
   projectName: string
 ): Promise<ProjectConfig | null> {
-  const configPath = path.join(
-    workspaceRoot,
-    projectName,
-    "projects",
-    projectName,
-    ".project.json"
-  );
-
+  const configPath = getProjectConfigPath(workspaceRoot, projectName);
   try {
     const content = await readFile(configPath, "utf-8");
     return JSON.parse(content);
@@ -42,13 +35,6 @@ export async function writeProjectConfig(
   projectName: string,
   config: ProjectConfig
 ): Promise<void> {
-  const configPath = path.join(
-    workspaceRoot,
-    projectName,
-    "projects",
-    projectName,
-    ".project.json"
-  );
-
+  const configPath = getProjectConfigPath(workspaceRoot, projectName);
   await writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
 }

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -5,6 +5,7 @@
 import { readdir, stat, readFile } from "node:fs/promises";
 import path from "node:path";
 import { findMainWorktree } from "./workspace.js";
+import { getIdeasDirPath } from "./paths.js";
 
 /**
  * Check if a file or directory exists
@@ -31,16 +32,14 @@ export async function getIdeaByNumber(
   const mainWorktree = await findMainWorktree(process.cwd());
   if (!mainWorktree) return null;
 
-  const ideasDir = path.join(mainWorktree, "ideas");
+  const ideasDir = getIdeasDirPath(mainWorktree);
   let files = await readdir(ideasDir);
   files.sort();
 
-  // Filter out rejected ideas unless explicitly requested
   if (!includeRejected) {
     files = files.filter(file => !file.startsWith("rejected-"));
   }
 
-  // Use 0-based indexing directly
   if (ideaNumber < 0 || ideaNumber >= files.length) {
     return null;
   }

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import path from "node:path";
+
+export const BARE_REPO_NAME = ".grind.repo.git";
+export const MAIN_WORKTREE_NAME = "grind";
+export const CONFIG_FILE_NAME = ".grind.json";
+export const PROJECT_CONFIG_FILE_NAME = ".project.json";
+export const PROJECTS_DIR_NAME = "projects";
+export const IDEAS_DIR_NAME = "ideas";
+export const JOURNAL_DIR_NAME = "journal";
+
+// --- Workspace roots ---
+
+export function getBareRepoPath(workspaceRoot: string): string {
+  return path.join(workspaceRoot, BARE_REPO_NAME);
+}
+
+export function getMainWorktreePath(workspaceRoot: string): string {
+  return path.join(workspaceRoot, MAIN_WORKTREE_NAME);
+}
+
+export function getProjectWorktreePath(workspaceRoot: string, projectName: string): string {
+  return path.join(workspaceRoot, projectName);
+}
+
+export function getProjectFilesPath(workspaceRoot: string, projectName: string): string {
+  return path.join(workspaceRoot, projectName, PROJECTS_DIR_NAME, projectName);
+}
+
+export function getProjectConfigPath(workspaceRoot: string, projectName: string): string {
+  return path.join(getProjectFilesPath(workspaceRoot, projectName), PROJECT_CONFIG_FILE_NAME);
+}
+
+export function getProjectIdeaPath(workspaceRoot: string, projectName: string): string {
+  return path.join(getProjectFilesPath(workspaceRoot, projectName), "the-idea.md");
+}
+
+// --- Main worktree internals ---
+
+export function getGrindConfigPath(mainWorktree: string): string {
+  return path.join(mainWorktree, CONFIG_FILE_NAME);
+}
+
+export function getIdeasDirPath(mainWorktree: string): string {
+  return path.join(mainWorktree, IDEAS_DIR_NAME);
+}
+
+export function getProjectsDirPath(mainWorktree: string): string {
+  return path.join(mainWorktree, PROJECTS_DIR_NAME);
+}
+
+export function getProjectConfigDirPath(mainWorktree: string, projectName: string): string {
+  return path.join(mainWorktree, PROJECTS_DIR_NAME, projectName);
+}
+
+export function getMainProjectConfigPath(mainWorktree: string, projectName: string): string {
+  return path.join(getProjectConfigDirPath(mainWorktree, projectName), PROJECT_CONFIG_FILE_NAME);
+}
+
+export function getMainProjectIdeaPath(mainWorktree: string, projectName: string): string {
+  return path.join(getProjectConfigDirPath(mainWorktree, projectName), "the-idea.md");
+}
+
+export function getJournalDirPath(mainWorktree: string): string {
+  return path.join(mainWorktree, JOURNAL_DIR_NAME);
+}
+
+export function getInvoiceDirPath(mainWorktree: string, projectName: string, invoiceId: string): string {
+  return path.join(getProjectConfigDirPath(mainWorktree, projectName), "invoices", invoiceId);
+}

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -5,6 +5,7 @@
 import path from "node:path";
 import { fileExists } from "./files.js";
 import { GrindUserError } from "./errors.js";
+import { BARE_REPO_NAME, MAIN_WORKTREE_NAME, getBareRepoPath, getMainWorktreePath, getGrindConfigPath } from "./paths.js";
 
 /**
  * Derive the current project name from the working directory.
@@ -21,15 +22,10 @@ export async function getCurrentProjectName(): Promise<string | null> {
 
   const firstSegment = relative.split(path.sep)[0];
 
-  // The "grind" directory is the main worktree, not a project
-  if (firstSegment === "grind" || firstSegment === ".grind.repo.git") return null;
+  if (firstSegment === MAIN_WORKTREE_NAME || firstSegment === BARE_REPO_NAME) return null;
 
   return firstSegment;
 }
-
-const BARE_REPO_NAME = ".grind.repo.git";
-const MAIN_WORKTREE_NAME = "grind";
-const CONFIG_FILE_NAME = ".grind.json";
 
 /**
  * Find the bare repo by scanning up from startPath
@@ -43,7 +39,6 @@ export async function findBareRepo(startPath: string): Promise<string | null> {
     if (await fileExists(bareRepoPath)) {
       return bareRepoPath;
     }
-    // Also check parent (worktrees are siblings to bare repo)
     const parentBareRepoPath = path.join(path.dirname(currentPath), BARE_REPO_NAME);
     if (await fileExists(parentBareRepoPath)) {
       return parentBareRepoPath;
@@ -70,8 +65,8 @@ export async function findMainWorktree(startPath: string): Promise<string | null
   const workspaceRoot = await getWorkspaceRoot(startPath);
   if (!workspaceRoot) return null;
 
-  const mainWorktreePath = path.join(workspaceRoot, MAIN_WORKTREE_NAME);
-  const configPath = path.join(mainWorktreePath, CONFIG_FILE_NAME);
+  const mainWorktreePath = getMainWorktreePath(workspaceRoot);
+  const configPath = getGrindConfigPath(mainWorktreePath);
 
   if (await fileExists(configPath)) {
     return mainWorktreePath;
@@ -99,7 +94,7 @@ export async function requireWorkspace(): Promise<{
     throw new GrindUserError("Could not find main worktree.");
   }
 
-  const bareRepo = path.join(workspaceRoot, BARE_REPO_NAME);
+  const bareRepo = getBareRepoPath(workspaceRoot);
 
   return { workspaceRoot, mainWorktree, bareRepo };
 }

--- a/tests/utils/paths.test.ts
+++ b/tests/utils/paths.test.ts
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import path from "node:path";
+import {
+  getBareRepoPath,
+  getMainWorktreePath,
+  getProjectWorktreePath,
+  getProjectFilesPath,
+  getProjectConfigPath,
+  getProjectIdeaPath,
+  getGrindConfigPath,
+  getIdeasDirPath,
+  getProjectsDirPath,
+  getProjectConfigDirPath,
+  getMainProjectConfigPath,
+  getMainProjectIdeaPath,
+  getJournalDirPath,
+  getInvoiceDirPath,
+  BARE_REPO_NAME,
+  MAIN_WORKTREE_NAME,
+  CONFIG_FILE_NAME,
+  PROJECT_CONFIG_FILE_NAME,
+  PROJECTS_DIR_NAME,
+  IDEAS_DIR_NAME,
+  JOURNAL_DIR_NAME,
+} from "../../src/utils/paths.js";
+
+describe("paths", () => {
+  const workspaceRoot = "/home/user/workspace";
+  const mainWorktree = "/home/user/workspace/grind";
+  const projectName = "my-project";
+
+  describe("workspace roots", () => {
+    it("getBareRepoPath", () => {
+      expect(getBareRepoPath(workspaceRoot)).toBe(
+        path.join(workspaceRoot, BARE_REPO_NAME),
+      );
+    });
+
+    it("getMainWorktreePath", () => {
+      expect(getMainWorktreePath(workspaceRoot)).toBe(
+        path.join(workspaceRoot, MAIN_WORKTREE_NAME),
+      );
+    });
+
+    it("getProjectWorktreePath", () => {
+      expect(getProjectWorktreePath(workspaceRoot, projectName)).toBe(
+        path.join(workspaceRoot, projectName),
+      );
+    });
+
+    it("getProjectFilesPath", () => {
+      expect(getProjectFilesPath(workspaceRoot, projectName)).toBe(
+        path.join(workspaceRoot, projectName, PROJECTS_DIR_NAME, projectName),
+      );
+    });
+
+    it("getProjectConfigPath", () => {
+      expect(getProjectConfigPath(workspaceRoot, projectName)).toBe(
+        path.join(workspaceRoot, projectName, PROJECTS_DIR_NAME, projectName, PROJECT_CONFIG_FILE_NAME),
+      );
+    });
+
+    it("getProjectIdeaPath", () => {
+      expect(getProjectIdeaPath(workspaceRoot, projectName)).toBe(
+        path.join(workspaceRoot, projectName, PROJECTS_DIR_NAME, projectName, "the-idea.md"),
+      );
+    });
+  });
+
+  describe("main worktree internals", () => {
+    it("getGrindConfigPath", () => {
+      expect(getGrindConfigPath(mainWorktree)).toBe(
+        path.join(mainWorktree, CONFIG_FILE_NAME),
+      );
+    });
+
+    it("getIdeasDirPath", () => {
+      expect(getIdeasDirPath(mainWorktree)).toBe(
+        path.join(mainWorktree, IDEAS_DIR_NAME),
+      );
+    });
+
+    it("getProjectsDirPath", () => {
+      expect(getProjectsDirPath(mainWorktree)).toBe(
+        path.join(mainWorktree, PROJECTS_DIR_NAME),
+      );
+    });
+
+    it("getProjectConfigDirPath", () => {
+      expect(getProjectConfigDirPath(mainWorktree, projectName)).toBe(
+        path.join(mainWorktree, PROJECTS_DIR_NAME, projectName),
+      );
+    });
+
+    it("getMainProjectConfigPath", () => {
+      expect(getMainProjectConfigPath(mainWorktree, projectName)).toBe(
+        path.join(mainWorktree, PROJECTS_DIR_NAME, projectName, PROJECT_CONFIG_FILE_NAME),
+      );
+    });
+
+    it("getMainProjectIdeaPath", () => {
+      expect(getMainProjectIdeaPath(mainWorktree, projectName)).toBe(
+        path.join(mainWorktree, PROJECTS_DIR_NAME, projectName, "the-idea.md"),
+      );
+    });
+
+    it("getJournalDirPath", () => {
+      expect(getJournalDirPath(mainWorktree)).toBe(
+        path.join(mainWorktree, JOURNAL_DIR_NAME),
+      );
+    });
+
+    it("getInvoiceDirPath", () => {
+      const invoiceId = "2026-01-27T14-30-15";
+      expect(getInvoiceDirPath(mainWorktree, projectName, invoiceId)).toBe(
+        path.join(mainWorktree, PROJECTS_DIR_NAME, projectName, "invoices", invoiceId),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Creates shared path resolution utilities to eliminate copy-pasted path construction across the codebase (closes #26).

## Changes

- **New:** `src/utils/paths.ts` — 14 named path functions and 7 string constants for all workspace path patterns
- **New:** `tests/utils/paths.test.ts` — unit tests for all path functions
- **Migrated:** 16 source files — every inline structural `path.join(...)` replaced with the corresponding named function
- **Zero user-facing change** — all paths resolve to the exact same strings

### Files migrated
`src/utils/config.ts`, `src/utils/files.ts`, `src/utils/workspace.ts`, `src/commands/cancel.ts`, `src/commands/clone.ts`, `src/commands/code.ts`, `src/commands/idea.ts`, `src/commands/init.ts`, `src/commands/invoice.ts`, `src/commands/journal.ts`, `src/commands/list.ts`, `src/commands/new.ts`, `src/commands/promote.ts`, `src/commands/prune.ts`, `src/commands/publish-project.ts`, `src/commands/reject.ts`, `src/commands/save.ts`, `src/commands/status.ts`, `src/commands/work.ts`

### Verification
- Typecheck: clean
- Tests: 26 passing (14 new + 12 existing)