### PR TITLE
Shared project config resolution utility (closes #28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grind",
-  "version": "0.6.81",
+  "version": "0.6.82",
   "description": "CLI tool for managing creative/technical projects from idea to publication",
   "type": "module",
   "main": "src/index.ts",

--- a/src/commands/invoice.ts
+++ b/src/commands/invoice.ts
@@ -3,14 +3,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import path from "node:path";
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { writeFile, mkdir } from "node:fs/promises";
 import { PassThrough } from "stream";
 import { requireWorkspace } from "../utils/workspace.js";
-import { readGrindConfig } from "../utils/config.js";
-import { fileExists } from "../utils/files.js";
+import { readGrindConfig, resolveProjectConfig } from "../utils/config.js";
 import { gitCommit } from "../utils/git.js";
 import { formatDate } from "../utils/time.js";
-import type { ProjectConfig, GrindConfig } from "../types/index.js";
+
 import PDFDocument from "pdfkit";
 import { GrindUserError } from "../utils/errors.js";
 
@@ -27,37 +26,13 @@ export async function invoiceProject(projectName: string): Promise<void> {
   // 2. Load workspace config for professional info
   const grindConfig = await readGrindConfig(mainWorktree);
 
-  // 3. Determine where to read .project.json from (ONE location only!)
-  const projectWorktreePath = path.join(workspaceRoot, projectName);
-  const projectWorktreeConfigPath = path.join(
-    projectWorktreePath,
-    "projects",
-    projectName,
-    ".project.json"
-  );
-  
-  const mainWorktreeConfigPath = path.join(
-    mainWorktree,
-    "projects",
-    projectName,
-    ".project.json"
-  );
-  
-  let configPath: string;
-
-  if (await fileExists(projectWorktreeConfigPath)) {
-    configPath = projectWorktreeConfigPath;
-    console.log(`Reading config from project worktree...`);
-  } else if (await fileExists(mainWorktreeConfigPath)) {
-    configPath = mainWorktreeConfigPath;
-    console.log(`Reading config from main worktree (project worktree not found)...`);
-  } else {
+  // 3. Resolve project config from worktree or main worktree
+  const result = await resolveProjectConfig(workspaceRoot, projectName);
+  if (!result) {
     throw new GrindUserError(`Project '${projectName}' not found.`);
   }
-  
-  // 4. Load project config
-  const configContent = await readFile(configPath, "utf-8");
-  const config: ProjectConfig = JSON.parse(configContent);
+  const { config, sourcePath: configPath } = result;
+  const projectWorktreePath = path.join(workspaceRoot, projectName);
 
   // 5. Filter sessions: only unbilled sessions with start AND end times
   const unbilledSessions = config.time.filter(

--- a/src/commands/promote.ts
+++ b/src/commands/promote.ts
@@ -2,46 +2,21 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import path from "node:path";
-import { readFile } from "node:fs/promises";
 import { $ } from "bun";
 import { requireWorkspace } from "../utils/workspace.js";
-import { fileExists } from "../utils/files.js";
-import type { ProjectConfig } from "../types/index.js";
 import { GrindUserError, GrindSystemError } from "../utils/errors.js";
+import { resolveProjectConfig } from "../utils/config.js";
 
 const N8N_WEBHOOK_URL = "https://gandalf.local:5678/webhook-test/promote";
 
 export async function promoteProject(projectName: string): Promise<void> {
-  const { workspaceRoot, mainWorktree } = await requireWorkspace();
+  const { workspaceRoot } = await requireWorkspace();
 
-  const projectWorktreeConfigPath = path.join(
-    workspaceRoot,
-    projectName,
-    "projects",
-    projectName,
-    ".project.json",
-  );
-
-  const mainWorktreeConfigPath = path.join(
-    mainWorktree,
-    "projects",
-    projectName,
-    ".project.json",
-  );
-
-  let configPath: string;
-
-  if (await fileExists(projectWorktreeConfigPath)) {
-    configPath = projectWorktreeConfigPath;
-  } else if (await fileExists(mainWorktreeConfigPath)) {
-    configPath = mainWorktreeConfigPath;
-  } else {
+  const result = await resolveProjectConfig(workspaceRoot, projectName);
+  if (!result) {
     throw new GrindUserError(`Project '${projectName}' not found.`);
   }
-
-  const configContent = await readFile(configPath, "utf-8");
-  const config: ProjectConfig = JSON.parse(configContent);
+  const { config } = result;
 
   if (!config.publications || config.publications.length === 0) {
     throw new GrindUserError(`Project '${projectName}' has no publication URLs.`);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,6 +5,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { GrindConfig, ProjectConfig } from "../types/index.js";
+import { fileExists } from "./files.js";
 
 export async function readGrindConfig(rootPath: string): Promise<GrindConfig> {
   const configPath = path.join(rootPath, ".grind.json");
@@ -51,4 +52,37 @@ export async function writeProjectConfig(
   );
 
   await writeFile(configPath, JSON.stringify(config, null, 2), "utf-8");
+}
+
+export async function resolveProjectConfig(
+  workspaceRoot: string,
+  projectName: string
+): Promise<{ config: ProjectConfig; sourcePath: string } | null> {
+  const projectWorktreePath = path.join(
+    workspaceRoot,
+    projectName,
+    "projects",
+    projectName,
+    ".project.json"
+  );
+
+  const mainWorktree = path.join(workspaceRoot, "grind");
+  const mainWorktreeConfigPath = path.join(
+    mainWorktree,
+    "projects",
+    projectName,
+    ".project.json"
+  );
+
+  if (await fileExists(projectWorktreePath)) {
+    const content = await readFile(projectWorktreePath, "utf-8");
+    return { config: JSON.parse(content), sourcePath: projectWorktreePath };
+  }
+
+  if (await fileExists(mainWorktreeConfigPath)) {
+    const content = await readFile(mainWorktreeConfigPath, "utf-8");
+    return { config: JSON.parse(content), sourcePath: mainWorktreeConfigPath };
+  }
+
+  return null;
 }

--- a/tests/utils/config.test.ts
+++ b/tests/utils/config.test.ts
@@ -4,7 +4,7 @@
 
 import * as fs from "node:fs/promises";
 import path from "node:path";  
-import { readGrindConfig, writeGrindConfig, readProjectConfig, writeProjectConfig } from "../../src/utils/config.ts";
+import { readGrindConfig, writeGrindConfig, readProjectConfig, writeProjectConfig, resolveProjectConfig } from "../../src/utils/config.ts";
 
 jest.mock("node:fs/promises");
 
@@ -70,6 +70,57 @@ describe('grind config utilities', () => {
 
     it("should read the config from .project.json in the project workspace", () => {
       expect(fs.readFile).toHaveBeenCalledWith(projectConfigPath, "utf-8");
+    });
+  });
+
+  describe('the resolveProjectConfig function', () => {
+    const project = "my-project";
+    const projectWorktreeConfigPath = path.join(rootPath, project, "projects", project, ".project.json");
+    const mainWorktreeConfigPath = path.join(rootPath, "grind", "projects", project, ".project.json");
+    const projectConfig = {
+      name: project,
+      idea: "test idea",
+      time: [],
+      billing: { roundTo: "quarter-hour", rate: 150 }
+    };
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return config from project worktree when it exists', async () => {
+      (fs.stat as jest.Mock).mockImplementation((p: string) =>
+        p === projectWorktreeConfigPath ? Promise.resolve() : Promise.reject(new Error("not found"))
+      );
+      (fs.readFile as jest.Mock).mockImplementation((p: string) =>
+        p === projectWorktreeConfigPath ? Promise.resolve(JSON.stringify(projectConfig)) : Promise.reject(new Error("not found"))
+      );
+
+      const result = await resolveProjectConfig(rootPath, project);
+      expect(result).not.toBeNull();
+      expect(result!.config.name).toBe(project);
+      expect(result!.sourcePath).toBe(projectWorktreeConfigPath);
+    });
+
+    it('should fall back to main worktree when project worktree does not exist', async () => {
+      (fs.stat as jest.Mock).mockImplementation((p: string) =>
+        p === mainWorktreeConfigPath ? Promise.resolve() : Promise.reject(new Error("not found"))
+      );
+      (fs.readFile as jest.Mock).mockImplementation((p: string) =>
+        p === mainWorktreeConfigPath ? Promise.resolve(JSON.stringify(projectConfig)) : Promise.reject(new Error("not found"))
+      );
+
+      const result = await resolveProjectConfig(rootPath, project);
+      expect(result).not.toBeNull();
+      expect(result!.config.name).toBe(project);
+      expect(result!.sourcePath).toBe(mainWorktreeConfigPath);
+    });
+
+    it('should return null when neither location has a config', async () => {
+      (fs.stat as jest.Mock).mockRejectedValue(new Error("not found"));
+
+      const result = await resolveProjectConfig(rootPath, project);
+      expect(result).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Motivation

The pattern of trying to read .project.json from the project worktree then falling back to the main worktree was duplicated verbatim in src/commands/promote.ts and src/commands/invoice.ts.

## Changes

- **src/utils/config.ts** — Added resolveProjectConfig(workspaceRoot, projectName) that returns { config, sourcePath } or null
- **src/commands/promote.ts** — Replaced inline fallback with resolveProjectConfig call
- **src/commands/invoice.ts** — Same refactor, uses sourcePath for write-back
- **tests/utils/config.test.ts** — Added 3 tests covering all resolution paths

## Verification

- tsc --noEmit passes
- All 15 tests pass