### PR TITLE
Shared worktree iteration utility — eliminate duplicate project-listing loops

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grind",
-  "version": "0.6.82",
+  "version": "0.6.83",
   "description": "CLI tool for managing creative/technical projects from idea to publication",
   "type": "module",
   "main": "src/index.ts",

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -5,10 +5,11 @@
 import path from "node:path";
 import { readFile, readdir } from "node:fs/promises";
 import { requireWorkspace } from "../utils/workspace.js";
-import { getActiveWorktrees } from "../utils/git.js";
 import { DIM, RED, RESET } from "../utils/colors.js";
-import type { ProjectConfig } from "../types/index.js";
 import { timeAgo } from "../utils/time.js";
+import { collectProjects } from "../utils/project.js";
+import type { ProjectConfig } from "../types/index.js";
+import type { ProjectEntry } from "../utils/project.js";
 
 /**
  * List all idea files for triage
@@ -65,22 +66,11 @@ export async function listIdeas(options?: {
  * grind list projects
  */
 export async function listProjects(): Promise<void> {
-  const { workspaceRoot, bareRepo } = await requireWorkspace();
+  const { workspaceRoot } = await requireWorkspace();
 
-  // Get active worktrees from git
-  const worktreeNames = await getActiveWorktrees(bareRepo, workspaceRoot);
-
-  // Load .project.json from each project's own worktree (has latest session data)
-  const projects: { config: ProjectConfig; dir: string }[] = [];
-  for (const name of worktreeNames) {
-    const configPath = path.join(workspaceRoot, name, "projects", name, ".project.json");
-    try {
-      const content = await readFile(configPath, "utf-8");
-      projects.push({ config: JSON.parse(content), dir: name });
-    } catch {
-      continue;
-    }
-  }
+  // Collect active project worktrees with their configs
+  const allProjects = await collectProjects(workspaceRoot);
+  const projects = allProjects.filter((p): p is ProjectEntry & { config: ProjectConfig } => p.config !== null);
 
   if (projects.length === 0) {
     console.log("No active projects. Create one with: grind new project \"name\" <idea-number>");
@@ -91,7 +81,7 @@ export async function listProjects(): Promise<void> {
   projects.sort((a, b) => {
     const aLast = a.config.time.length > 0 ? a.config.time[a.config.time.length - 1].start : null;
     const bLast = b.config.time.length > 0 ? b.config.time[b.config.time.length - 1].start : null;
-    if (!aLast && !bLast) return a.dir.localeCompare(b.dir);
+    if (!aLast && !bLast) return a.name.localeCompare(b.name);
     if (!aLast) return -1;
     if (!bLast) return 1;
     return new Date(aLast).getTime() - new Date(bLast).getTime();

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -4,13 +4,14 @@
 
 import { $ } from "bun";
 import path from "node:path";
-import { readFile } from "node:fs/promises";
 import { requireWorkspace } from "../utils/workspace.js";
-import { getCommitCount, getFirstCommitDate, getLastCommitDate, getActiveWorktrees } from "../utils/git.js";
+import { getCommitCount, getFirstCommitDate, getLastCommitDate } from "../utils/git.js";
 import { timeAgo, formatDate } from "../utils/time.js";
 import { parseRepoUrl } from "../utils/repo.js";
 import { DIM, RED, GREEN, RESET } from "../utils/colors.js";
+import { collectProjects } from "../utils/project.js";
 import type { ProjectConfig } from "../types/index.js";
+import type { ProjectEntry } from "../utils/project.js";
 
 interface ProjectRow {
   name: string;
@@ -61,20 +62,9 @@ async function getIssueCount(repo: string): Promise<string> {
 export async function status(): Promise<void> {
   const { workspaceRoot, bareRepo } = await requireWorkspace();
 
-  // Get active worktrees from git
-  const worktreeNames = await getActiveWorktrees(bareRepo, workspaceRoot);
-
-  // Load project configs
-  const projects: { config: ProjectConfig; name: string; branch: string }[] = [];
-  for (const name of worktreeNames) {
-    const configPath = path.join(workspaceRoot, name, "projects", name, ".project.json");
-    try {
-      const content = await readFile(configPath, "utf-8");
-      projects.push({ config: JSON.parse(content), name, branch: name });
-    } catch {
-      continue;
-    }
-  }
+  // Collect active project worktrees with their configs
+  const allProjects = await collectProjects(workspaceRoot);
+  const projects = allProjects.filter((p): p is ProjectEntry & { config: ProjectConfig } => p.config !== null);
 
   if (projects.length === 0) {
     console.log("No active projects. Create one with: grind new project \"name\" <idea-number>");
@@ -82,9 +72,9 @@ export async function status(): Promise<void> {
   }
 
   // Build rows in parallel
-  const rowPromises = projects.map(async ({ config, name, branch }): Promise<ProjectRow> => {
+  const rowPromises = projects.map(async ({ config, name, worktreePath }): Promise<ProjectRow> => {
     // Git queries
-    const worktreePath = path.join(workspaceRoot, name);
+    const branch = name;
     const [commitCount, firstCommitDate, lastCommitDate, issueCount, hasChanges] = await Promise.all([
       getCommitCount(bareRepo, branch),
       getFirstCommitDate(bareRepo, branch),

--- a/src/utils/project.ts
+++ b/src/utils/project.ts
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+import { getActiveWorktrees } from "./git.js";
+import type { ProjectConfig } from "../types/index.js";
+
+export interface ProjectEntry {
+  name: string;
+  worktreePath: string;
+  config: ProjectConfig | null;
+}
+
+const BARE_REPO_NAME = ".grind.repo.git";
+
+/**
+ * Collect all active project worktrees (excluding main "grind" worktree)
+ * and load their configs.
+ */
+export async function collectProjects(workspaceRoot: string): Promise<ProjectEntry[]> {
+  const bareRepo = path.join(workspaceRoot, BARE_REPO_NAME);
+  const worktreeNames = await getActiveWorktrees(bareRepo, workspaceRoot);
+
+  const projects: ProjectEntry[] = [];
+  for (const name of worktreeNames) {
+    const configPath = path.join(workspaceRoot, name, "projects", name, ".project.json");
+    try {
+      const content = await readFile(configPath, "utf-8");
+      projects.push({
+        name,
+        worktreePath: path.join(workspaceRoot, name),
+        config: JSON.parse(content) as ProjectConfig,
+      });
+    } catch {
+      projects.push({
+        name,
+        worktreePath: path.join(workspaceRoot, name),
+        config: null,
+      });
+    }
+  }
+
+  return projects;
+}

--- a/tests/utils/project.test.ts
+++ b/tests/utils/project.test.ts
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import path from "node:path";
+import * as fs from "node:fs/promises";
+import { collectProjects } from "../../src/utils/project.ts";
+
+jest.mock("bun");
+jest.mock("node:fs/promises");
+
+const mock$ = jest.requireMock("bun").$ as jest.Mock;
+
+describe("collectProjects", () => {
+  const workspaceRoot = "/home/user/work";
+  const sampleConfig = {
+    name: "my-project",
+    idea: "A test project",
+    time: [],
+    billing: { roundTo: "quarter-hour" as const, rate: 150 },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mock$.mockImplementation(() => ({
+      quiet: jest.fn().mockResolvedValue({ stdout: Buffer.from("") }),
+    }));
+  });
+
+  it("returns correct entries from a mocked worktree list", async () => {
+    mock$.mockImplementation(() => ({
+      quiet: jest.fn().mockResolvedValue({
+        stdout: Buffer.from(
+          `worktree ${workspaceRoot}/my-project\nHEAD abc123...\nbranch refs/heads/my-project\n\nworktree ${workspaceRoot}/grind\nHEAD def456...\nbranch refs/heads/main\n`
+        ),
+      }),
+    }));
+
+    (fs.readFile as jest.Mock).mockImplementation((filePath: string) => {
+      if (filePath.includes("my-project") && filePath.endsWith(".project.json")) {
+        return Promise.resolve(JSON.stringify(sampleConfig));
+      }
+      return Promise.reject(new Error("not found"));
+    });
+
+    const result = await collectProjects(workspaceRoot);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("my-project");
+    expect(result[0].worktreePath).toBe(path.join(workspaceRoot, "my-project"));
+    expect(result[0].config).not.toBeNull();
+    expect(result[0].config!.name).toBe("my-project");
+  });
+
+  it("returns config: null for projects without a config file", async () => {
+    mock$.mockImplementation(() => ({
+      quiet: jest.fn().mockResolvedValue({
+        stdout: Buffer.from(
+          `worktree ${workspaceRoot}/no-config-project\nHEAD abc123...\nbranch refs/heads/no-config-project\n`
+        ),
+      }),
+    }));
+
+    (fs.readFile as jest.Mock).mockRejectedValue(new Error("not found"));
+
+    const result = await collectProjects(workspaceRoot);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("no-config-project");
+    expect(result[0].config).toBeNull();
+  });
+
+  it("filters out the main grind worktree", async () => {
+    mock$.mockImplementation(() => ({
+      quiet: jest.fn().mockResolvedValue({
+        stdout: Buffer.from(
+          `worktree ${workspaceRoot}/grind\nHEAD def456...\nbranch refs/heads/main\n`
+        ),
+      }),
+    }));
+
+    const result = await collectProjects(workspaceRoot);
+
+    expect(result).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #29

## Changes
- **New**: `src/utils/project.ts` — `ProjectEntry` interface and `collectProjects()` utility
- **Refactored**: `src/commands/list.ts` — uses `collectProjects()` instead of inline loop
- **Refactored**: `src/commands/status.ts` — uses `collectProjects()` instead of inline loop
- **Tests**: `tests/utils/project.test.ts` — covers successful collection, missing config, and grind worktree filtering