### PR TITLE
Consolidate work/edit/code/save into unified grind work + save -t backfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grind",
-  "version": "0.6.83",
+  "version": "0.6.84",
   "description": "CLI tool for managing creative/technical projects from idea to publication",
   "type": "module",
   "main": "src/index.ts",

--- a/src/commands/code.ts
+++ b/src/commands/code.ts
@@ -2,72 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import path from "node:path";
-import { requireWorkspace } from "../utils/workspace.js";
-import { fileExists } from "../utils/files.js";
-import { readProjectConfig, writeProjectConfig } from "../utils/config.js";
-import { getCurrentTimestamp } from "../utils/time.js";
-import type { Session } from "../types/index.js";
-import { GrindUserError } from "../utils/errors.js";
-import { openEditorDetached } from "../utils/editor.js";
+import { workStart } from "./work.js";
 
 /**
- * Open code editor in project's code directory & start work session
- * grind code <project-name>
+ * Open code editor in project's code directory (no timer)
+ * grind code <project>
  */
 export async function openCode(projectName: string): Promise<void> {
-  const { workspaceRoot } = await requireWorkspace();
-
-  // Verify project worktree exists
-  const worktreePath = path.join(workspaceRoot, projectName);
-  if (!(await fileExists(worktreePath))) {
-    throw new GrindUserError(`Project '${projectName}' does not exist.`);
-  }
-
-  const config = await readProjectConfig(workspaceRoot, projectName);
-  if (!config) {
-    throw new GrindUserError(`Could not read .project.json for '${projectName}'.`);
-  }
-
-  if (!config.code) {
-    throw new GrindUserError(
-      `No code directory set for '${projectName}'. Run:\n  grind config -p ${projectName} code <directory>`
-    );
-  }
-
-  const codeDir = path.isAbsolute(config.code)
-    ? config.code
-    : path.join(worktreePath, config.code);
-
-  if (!(await fileExists(codeDir))) {
-    throw new GrindUserError(`Code directory '${codeDir}' does not exist.`);
-  }
-
-  // Check for active session and auto-close with 0 duration if found
-  const activeSession = config.time.find(s => s.end === null);
-  if (activeSession) {
-    console.log(`Warning: Found unclosed session. Auto-closing with 0 duration.`);
-    activeSession.end = activeSession.start;
-    activeSession.duration = 0;
-    activeSession.rounded = 0;
-  }
-
-  // Add new session
-  const newSession: Session = {
-    start: getCurrentTimestamp(),
-    end: null,
-    duration: 0,
-    rounded: 0
-  };
-
-  config.time.push(newSession);
-
-  // Write updated config
-  await writeProjectConfig(workspaceRoot, projectName, config);
-
-  console.log(`Started work session on '${projectName}'`);
-  console.log(`Time started: ${newSession.start}`);
-
-  // Open code directory in editor
-  await openEditorDetached(codeDir);
+  await workStart(projectName, { code: true, quiet: true });
 }

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -7,6 +7,7 @@ import { requireWorkspace } from "../utils/workspace.js";
 import { getIdeaByNumber } from "../utils/files.js";
 import { GrindUserError } from "../utils/errors.js";
 import { openEditor } from "../utils/editor.js";
+import { workStart } from "./work.js";
 
 /**
  * Open an idea file in $EDITOR
@@ -27,4 +28,12 @@ export async function editIdea(ideaNumber: string): Promise<void> {
 
   const filepath = path.join(mainWorktree, "ideas", idea.filename);
   await openEditor(filepath);
+}
+
+/**
+ * Open a project's writing directory in editor (no timer)
+ * grind edit <project>
+ */
+export async function editProject(projectName: string): Promise<void> {
+  await workStart(projectName, { quiet: true });
 }

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -5,26 +5,17 @@
 import path from "node:path";
 import { requireWorkspace } from "../utils/workspace.js";
 import { readProjectConfig, writeProjectConfig } from "../utils/config.js";
-import { getCurrentTimestamp, calculateDuration, roundTimeByStrategy } from "../utils/time.js";
+import { getActiveSession, endSession } from "../utils/session.js";
 import { gitCommit, gitCommitInteractive, hasUncommittedChanges } from "../utils/git.js";
 import { GrindUserError } from "../utils/errors.js";
 
-/**
- * Save work on a project
- * grind save "project" [-q|--quiet]
- *
- * - Stops the timer
- * - Commits changes
- *   - Default: Opens interactive editor for commit message
- *   - With -q flag: Uses auto-generated message with warning
- */
-export async function save(projectName: string, options?: { quiet?: boolean }): Promise<void> {
+export async function save(
+  projectName: string,
+  options?: { quiet?: boolean; time?: string },
+): Promise<void> {
   const { workspaceRoot } = await requireWorkspace();
-
   const worktreePath = path.join(workspaceRoot, projectName);
 
-  // The 'grind' worktree is the main worktree with no .project.json —
-  // just stage and commit, no time tracking or billing.
   if (projectName === "grind") {
     console.log("Saving grind worktree...");
     if (await hasUncommittedChanges(worktreePath)) {
@@ -36,26 +27,32 @@ export async function save(projectName: string, options?: { quiet?: boolean }): 
     return;
   }
 
-  // Read project config
   const config = await readProjectConfig(workspaceRoot, projectName);
   if (!config) {
     throw new GrindUserError(`Could not read .project.json for '${projectName}'.`);
   }
 
-  // Find and stop active session (if any)
-  const activeSession = config.time.find(s => s.end === null);
+  let endTime: string | undefined;
+  if (options?.time) {
+    const hours = parseFloat(options.time);
+    if (isNaN(hours) || hours <= 0) {
+      throw new GrindUserError("Backfill time (-t) must be a positive number (hours as decimal).");
+    }
+    const activeSession = getActiveSession(config);
+    if (activeSession) {
+      const startMs = new Date(activeSession.start).getTime();
+      endTime = new Date(startMs + hours * 3600 * 1000).toISOString();
+    }
+  }
+
+  const endedSession = endSession(config, endTime);
   let roundedHours: string | undefined;
 
-  if (activeSession) {
-    const endTime = getCurrentTimestamp();
-    activeSession.end = endTime;
-    activeSession.duration = calculateDuration(activeSession.start, endTime);
-    activeSession.rounded = roundTimeByStrategy(activeSession.duration, config.billing.roundTo);
-
+  if (endedSession) {
     await writeProjectConfig(workspaceRoot, projectName, config);
 
-    const hours = (activeSession.duration / 3600).toFixed(2);
-    roundedHours = (activeSession.rounded / 3600).toFixed(2);
+    const hours = (endedSession.duration / 3600).toFixed(2);
+    roundedHours = (endedSession.rounded / 3600).toFixed(2);
 
     console.log(`Stopped work session on '${projectName}'`);
     console.log(`Duration: ${hours} hours (${roundedHours} hours rounded)`);
@@ -63,7 +60,6 @@ export async function save(projectName: string, options?: { quiet?: boolean }): 
     console.log("No active sessions found.");
   }
 
-  // Commit changes (if any)
   if (await hasUncommittedChanges(worktreePath)) {
     console.log(`Committing changes...`);
 

--- a/src/commands/work.ts
+++ b/src/commands/work.ts
@@ -6,55 +6,65 @@ import path from "node:path";
 import { requireWorkspace } from "../utils/workspace.js";
 import { fileExists } from "../utils/files.js";
 import { readProjectConfig, writeProjectConfig } from "../utils/config.js";
-import { getCurrentTimestamp } from "../utils/time.js";
-import type { Session } from "../types/index.js";
+import { getActiveSession, startSession } from "../utils/session.js";
 import { GrindUserError } from "../utils/errors.js";
 import { openEditorDetached } from "../utils/editor.js";
+import { save } from "./save.js";
 
-/**
- * Start working on a project
- * grind work "project-name" [-q|--quiet]
- */
-export async function workStart(projectName: string, options?: { quiet?: boolean }): Promise<void> {
+export async function workStart(
+  projectName: string,
+  options?: { code?: boolean; quiet?: boolean; save?: boolean },
+): Promise<void> {
   const { workspaceRoot } = await requireWorkspace();
 
-  // Verify project worktree exists
   const worktreePath = path.join(workspaceRoot, projectName);
   if (!(await fileExists(worktreePath))) {
     throw new GrindUserError(`Project '${projectName}' does not exist.`);
   }
 
-  if (!options?.quiet) {
-    const config = await readProjectConfig(workspaceRoot, projectName);
-    if (!config) {
-      throw new GrindUserError(`Could not read .project.json for '${projectName}'.`);
+  if (options?.save) {
+    if (options.code || options.quiet) {
+      throw new GrindUserError("Cannot combine -s with -c or -q flags.");
     }
+    await save(projectName, options);
+    return;
+  }
 
-    // Check for active session - keep it open if exists (orphaned session)
-    const activeSession = config.time.find(s => s.end === null);
+  const config = await readProjectConfig(workspaceRoot, projectName);
+  if (!config) {
+    throw new GrindUserError(`Could not read .project.json for '${projectName}'.`);
+  }
 
+  let targetDir: string;
+  if (options?.code) {
+    if (!config.code) {
+      throw new GrindUserError(
+        `No code directory set for '${projectName}'. Run:\n  grind config -p ${projectName} code <directory>`,
+      );
+    }
+    targetDir = path.isAbsolute(config.code)
+      ? config.code
+      : path.join(worktreePath, config.code);
+    if (!(await fileExists(targetDir))) {
+      throw new GrindUserError(`Code directory '${targetDir}' does not exist.`);
+    }
+  } else {
+    targetDir = path.join(worktreePath, "projects", projectName);
+  }
+
+  if (!options?.quiet) {
+    const activeSession = getActiveSession(config);
     if (activeSession) {
       console.log(`Continuing session on '${projectName}'`);
       console.log(`Session started: ${activeSession.start}`);
     } else {
-      // Add new session only if no orphaned session
-      const newSession: Session = {
-        start: getCurrentTimestamp(),
-        end: null,
-        duration: 0,
-        rounded: 0
-      };
-      config.time.push(newSession);
-
+      const newSession = startSession(config);
       console.log(`Started work session on '${projectName}'`);
       console.log(`Time started: ${newSession.start}`);
     }
 
-    // Write updated config
     await writeProjectConfig(workspaceRoot, projectName, config);
   }
 
-  // Open editor in project directory
-  const projectDir = path.join(worktreePath, "projects", projectName);
-  openEditorDetached(projectDir);
+  await openEditorDetached(targetDir);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import { pruneIdeas } from "./commands/prune.js";
 import { publishProject } from "./commands/publish-project.js";
 import { cancelProject } from "./commands/cancel.js";
 import { invoiceProject } from "./commands/invoice.js";
-import { editIdea } from "./commands/edit.js";
+import { editIdea, editProject } from "./commands/edit.js";
 import { openCode } from "./commands/code.js";
 import { journal } from "./commands/journal.js";
 import { status } from "./commands/status.js";
@@ -215,17 +215,26 @@ program
     await listProjects();
   });
 
-// grind work "project" [-q|--quiet]
+// grind work <project> [-c] [-q] [-s]
 program
   .command("work <project>")
   .description("Start working on a project (starts timer, opens editor)")
+  .option("-c, --code", "Open code directory instead of project directory")
   .option("-q, --quiet", "Open editor without starting a timer")
-  .action(async (project: string, options: { quiet?: boolean }) => {
-    await workStart(project, options);
-  });
+  .option("-s, --save", "Save work (end timer, commit)")
+  .action(
+    async (
+      project: string,
+      options: { code?: boolean; quiet?: boolean; save?: boolean },
+    ) => {
+      await workStart(project, options);
+    },
+  );
 
-// grind edit idea <number>
-const editCmd = program.command("edit").description("Open files in editor");
+// grind edit [target] — opens project writing dir or idea
+const editCmd = program
+  .command("edit [target]")
+  .description("Open a project or idea in editor");
 
 editCmd
   .command("idea <number>")
@@ -233,6 +242,14 @@ editCmd
   .action(async (number: string) => {
     await editIdea(number);
   });
+
+editCmd.action(async (target?: string) => {
+  if (!target) {
+    editCmd.help();
+  } else {
+    await editProject(target);
+  }
+});
 
 // grind code <project>
 program
@@ -242,14 +259,20 @@ program
     await openCode(project);
   });
 
-// grind save "project"
+// grind save "project" [-q] [-t <hours>]
 program
   .command("save <project>")
   .description("Save work on a project (stops timer, commits changes)")
   .option("-q, --quiet", "Use auto-generated commit message (quick save)")
-  .action(async (project: string, options: { quiet?: boolean }) => {
-    await save(project, options);
-  });
+  .option(
+    "-t, --time <hours>",
+    "Backfill: set session end time to start + N hours",
+  )
+  .action(
+    async (project: string, options: { quiet?: boolean; time?: string }) => {
+      await save(project, options);
+    },
+  );
 
 // grind publish <name> [-d] [-D] [-u <url>]
 program

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import type { ProjectConfig, Session } from "../types/index.js";
+import { getCurrentTimestamp, calculateDuration, roundTimeByStrategy } from "./time.js";
+
+export function getActiveSession(config: ProjectConfig): Session | undefined {
+  return config.time.find(s => s.end === null);
+}
+
+export function startSession(config: ProjectConfig): Session {
+  const newSession: Session = {
+    start: getCurrentTimestamp(),
+    end: null,
+    duration: 0,
+    rounded: 0,
+  };
+  config.time.push(newSession);
+  return newSession;
+}
+
+export function endSession(
+  config: ProjectConfig,
+  endTime?: string,
+): Session | undefined {
+  const session = getActiveSession(config);
+  if (!session) return undefined;
+
+  const effectiveEnd = endTime ?? getCurrentTimestamp();
+  session.end = effectiveEnd;
+  session.duration = calculateDuration(session.start, effectiveEnd);
+  session.rounded = roundTimeByStrategy(session.duration, config.billing.roundTo);
+  return session;
+}
+
+export function closeOrphanedSession(config: ProjectConfig): void {
+  const activeSession = getActiveSession(config);
+  if (activeSession) {
+    activeSession.end = activeSession.start;
+    activeSession.duration = 0;
+    activeSession.rounded = 0;
+  }
+}


### PR DESCRIPTION
Four overlapping commands (work/edit/code/save) unified into one daily-driver command with -c, -q, -s flags. Added shared session utility (start/end primitives), save -t backfill flag. edit and code are now thin aliases. Closes #30.