### PR TITLE
Configurable default branch name — stop hard-coding 'main'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grind",
-  "version": "0.6.85",
+  "version": "0.6.86",
   "description": "CLI tool for managing creative/technical projects from idea to publication",
   "type": "module",
   "main": "src/index.ts",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,7 +5,7 @@
 import path from "node:path";
 import { mkdir, writeFile } from "node:fs/promises";
 import type { GrindConfig } from "../types/index.js";
-import { gitInit, gitInitialCommit, gitAddWorktree, gitCommit } from "../utils/git.js";
+import { gitInit, gitInitialCommit, gitAddWorktree, gitCommit, getDefaultBranch } from "../utils/git.js";
 import { fileExists } from "../utils/files.js";
 import { GrindUserError } from "../utils/errors.js";
 
@@ -43,15 +43,19 @@ export async function init(): Promise<void> {
   console.log("Creating bare repository...");
   await gitInit(bareRepoPath);
 
-  // 2. Create initial commit (required for worktrees)
+  // 2. Determine default branch name
+  const defaultBranch = await getDefaultBranch(bareRepoPath);
+  console.log(`Using branch '${defaultBranch}' as default...`);
+
+  // 3. Create initial commit (required for worktrees)
   console.log("Creating initial commit...");
-  await gitInitialCommit(bareRepoPath);
+  await gitInitialCommit(bareRepoPath, defaultBranch);
 
-  // 3. Add main worktree
+  // 4. Add main worktree
   console.log("Creating main worktree (grind/)...");
-  await gitAddWorktree(bareRepoPath, mainWorktreePath, "main");
+  await gitAddWorktree(bareRepoPath, mainWorktreePath, defaultBranch);
 
-  // 4. Create structure in main worktree
+  // 5. Create structure in main worktree
   console.log("Setting up workspace structure...");
   await mkdir(path.join(mainWorktreePath, "ideas"), { recursive: true });
   await mkdir(path.join(mainWorktreePath, "projects"), { recursive: true });
@@ -61,7 +65,7 @@ export async function init(): Promise<void> {
     "utf-8"
   );
 
-  // 5. Commit the structure
+  // 6. Commit the structure
   console.log("Committing initial structure...");
   await gitCommit(mainWorktreePath, "Initialize grind workspace");
 

--- a/src/commands/publish-project.ts
+++ b/src/commands/publish-project.ts
@@ -6,8 +6,8 @@ import { $ } from "bun";
 import path from "node:path";
 import { requireWorkspace } from "../utils/workspace.js";
 import { fileExists } from "../utils/files.js";
-import { hasUncommittedChanges } from "../utils/git.js";
-import { readProjectConfig, writeProjectConfig } from "../utils/config.js";
+import { getDefaultBranch, hasUncommittedChanges } from "../utils/git.js";
+import { readGrindConfig, readProjectConfig, writeProjectConfig } from "../utils/config.js";
 import { getCurrentTimestamp } from "../utils/time.js";
 import { GrindUserError, GrindSystemError } from "../utils/errors.js";
 
@@ -53,16 +53,20 @@ export async function publishProject(
     console.log(`  - Recorded publication: ${options.url}`);
   }
 
-  // 5. Switch to main branch in grind/ worktree
+  // 5. Determine default branch name
+  const config = await readGrindConfig(mainWorktree);
+  const defaultBranch = await getDefaultBranch(bareRepo, config);
+
+  // 6. Switch to default branch in grind/ worktree
   try {
-    await $`git -C ${mainWorktree} switch main`.quiet();
+    await $`git -C ${mainWorktree} switch ${defaultBranch}`.quiet();
   } catch {
-    throw new GrindSystemError("Could not switch to main branch. Is it checked out in another worktree?");
+    throw new GrindSystemError(`Could not switch to ${defaultBranch} branch. Is it checked out in another worktree?`);
   }
 
-  // 6. Merge project branch into main
+  // 7. Merge project branch into default branch
   console.log(`Publishing project '${projectName}'...`);
-  console.log(`Merging branch '${projectName}' into main...`);
+  console.log(`Merging branch '${projectName}' into ${defaultBranch}...`);
 
   try {
     await $`git -C ${mainWorktree} merge ${projectName}`.quiet();
@@ -71,7 +75,7 @@ export async function publishProject(
     throw new GrindSystemError(`Merge failed. Please resolve conflicts manually in ${mainWorktree}`);
   }
 
-  // 7. If -d or -D flag: remove worktree (and optionally branch)
+  // 8. If -d or -D flag: remove worktree (and optionally branch)
   if (options?.deleteWorktree || options?.deleteBranch) {
     console.log("\nCleaning up worktree...");
     await $`git -C ${bareRepo} worktree remove ${worktreePath}`.quiet();
@@ -84,7 +88,7 @@ export async function publishProject(
 
     console.log(`\nProject '${projectName}' published and archived.`);
   } else {
-    console.log(`\nProject '${projectName}' published to main branch.`);
+    console.log(`\nProject '${projectName}' published to ${defaultBranch} branch.`);
     console.log("Worktree and branch preserved for future work.");
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,7 @@ export interface GrindConfig {
     roundTo: RoundTo;
     defaultRate: number;
   };
+  defaultBranch?: string; // Custom default branch name (default: "main")
   projectTypes?: string[]; // Override default project types
   my?: ProfessionalInfo;
   currency?: string;

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -5,6 +5,7 @@
 import { execSync } from "node:child_process";
 import path from "node:path";
 import { $ } from "bun";
+import type { GrindConfig } from "../types/index.js";
 
 /**
  * Initialize a bare git repository (for use with worktrees)
@@ -35,10 +36,33 @@ export async function gitCommitInteractive(worktreePath: string): Promise<void> 
 }
 
 /**
+ * Resolve the default branch name for the workspace.
+ * Resolution order: explicit config > detected from bare repo > "main"
+ */
+export async function getDefaultBranch(
+  bareRepoPath: string,
+  config?: GrindConfig
+): Promise<string> {
+  if (config?.defaultBranch) {
+    return config.defaultBranch;
+  }
+
+  try {
+    const result = await $`git -C ${bareRepoPath} symbolic-ref HEAD`.quiet();
+    const ref = result.stdout.toString().trim();
+    if (ref.startsWith("refs/heads/")) {
+      return ref.substring("refs/heads/".length);
+    }
+  } catch {}
+
+  return "main";
+}
+
+/**
  * Create initial empty commit in a bare repo (required before adding worktrees)
  * Uses low-level git plumbing commands since bare repos have no working tree
  */
-export async function gitInitialCommit(repoPath: string): Promise<void> {
+export async function gitInitialCommit(repoPath: string, branchName: string = "main"): Promise<void> {
   // Create empty tree object
   const treeResult = await $`git -C ${repoPath} hash-object -t tree /dev/null`.quiet();
   const treeHash = treeResult.stdout.toString().trim();
@@ -47,8 +71,8 @@ export async function gitInitialCommit(repoPath: string): Promise<void> {
   const commitResult = await $`git -C ${repoPath} commit-tree ${treeHash} -m "Initial commit"`.quiet();
   const commitHash = commitResult.stdout.toString().trim();
 
-  // Update main branch to point to commit
-  await $`git -C ${repoPath} update-ref refs/heads/main ${commitHash}`.quiet();
+  // Update branch to point to commit
+  await $`git -C ${repoPath} update-ref refs/heads/${branchName} ${commitHash}`.quiet();
 }
 
 /**

--- a/tests/utils/git.test.ts
+++ b/tests/utils/git.test.ts
@@ -2,11 +2,64 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { getFirstCommitDate } from "../../src/utils/git.ts";
+import { getDefaultBranch, getFirstCommitDate } from "../../src/utils/git.ts";
+import type { GrindConfig } from "../../src/types/index.js";
 
 jest.mock("bun");
 
 const mock$ = jest.requireMock("bun").$ as jest.Mock;
+
+describe("getDefaultBranch", () => {
+  const bareRepoPath = "/fake/repo.git";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mock$.mockImplementation(() => ({
+      quiet: jest.fn().mockResolvedValue({ stdout: Buffer.from("") }),
+    }));
+  });
+
+  it("returns config value when set", async () => {
+    const config: GrindConfig = {
+      billing: { roundTo: "quarter-hour", defaultRate: 150 },
+      defaultBranch: "trunk",
+    };
+    const result = await getDefaultBranch(bareRepoPath, config);
+    expect(result).toBe("trunk");
+  });
+
+  it("falls back to detected branch from git symbolic-ref", async () => {
+    mock$.mockImplementation(() => ({
+      quiet: jest.fn().mockResolvedValue({
+        stdout: Buffer.from("refs/heads/develop\n"),
+      }),
+    }));
+    const result = await getDefaultBranch(bareRepoPath);
+    expect(result).toBe("develop");
+  });
+
+  it("falls back to main when neither config nor symbolic-ref is available", async () => {
+    mock$.mockImplementation(() => ({
+      quiet: jest.fn().mockRejectedValue(new Error("not a git repository")),
+    }));
+    const result = await getDefaultBranch(bareRepoPath);
+    expect(result).toBe("main");
+  });
+
+  it("prioritizes config over git symbolic-ref", async () => {
+    const config: GrindConfig = {
+      billing: { roundTo: "quarter-hour", defaultRate: 150 },
+      defaultBranch: "primary",
+    };
+    mock$.mockImplementation(() => ({
+      quiet: jest.fn().mockResolvedValue({
+        stdout: Buffer.from("refs/heads/main\n"),
+      }),
+    }));
+    const result = await getDefaultBranch(bareRepoPath, config);
+    expect(result).toBe("primary");
+  });
+});
 
 describe("getFirstCommitDate", () => {
   const repoPath = "/fake/repo.git";


### PR DESCRIPTION
## Changes

Adds a `defaultBranch` config option to `.grind.json` so workspaces can use a branch name other than `main`.

### Resolution order
1. Explicit `defaultBranch` in workspace config
2. Detected from bare repo via `git symbolic-ref HEAD`
3. Fallback: `main`

### Files changed
- `src/types/index.ts` — Added `defaultBranch?: string` to `GrindConfig`
- `src/utils/git.ts` — Added `getDefaultBranch()`, updated `gitInitialCommit` to accept branch name
- `src/commands/init.ts` — Uses `getDefaultBranch` instead of hard-coded `main`
- `src/commands/publish-project.ts` — Uses `getDefaultBranch` instead of hard-coded `main`
- `tests/utils/git.test.ts` — 4 new unit tests covering all resolution paths

Closes #33