### PR TITLE
Consistent confirmation model across destructive commands (--yes flag)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,8 @@ workspace-root/
 - `src/utils/time.ts` — timestamp generation, duration calculation, rounding, `timeAgo`/`formatDate` helpers
 - `src/utils/colors.ts` — shared ANSI color constants (`DIM`, `RED`, `GREEN`, `RESET`)
 
+**Prompts:** `src/utils/prompts.ts` provides `confirmOrExit(prompt, skip)` — prints a y/N prompt and exits unless the user confirms. Pass `skip=true` to bypass (used by `-y`/`--yes` flags). The function reads stdin via `node:readline/promises`.
+
 **Invoicing:** `src/commands/invoice.ts` generates both markdown and PDF (via pdfkit) invoices from tracked time sessions.
 
 ## Conventions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grind",
-  "version": "0.6.86",
+  "version": "0.6.87",
   "description": "CLI tool for managing creative/technical projects from idea to publication",
   "type": "module",
   "main": "src/index.ts",

--- a/src/commands/cancel.ts
+++ b/src/commands/cancel.ts
@@ -8,15 +8,16 @@ import { rm } from "node:fs/promises";
 import { requireWorkspace } from "../utils/workspace.js";
 import { fileExists } from "../utils/files.js";
 import { gitCommit } from "../utils/git.js";
+import { confirmOrExit } from "../utils/prompts.js";
 import { GrindUserError, GrindSystemError } from "../utils/errors.js";
 
 /**
  * Cancel (abandon) a project
- * grind cancel <name> [--force]
+ * grind cancel <name> [--force] [-y]
  */
 export async function cancelProject(
   projectName: string,
-  options?: { force?: boolean }
+  options?: { force?: boolean; yes?: boolean }
 ): Promise<void> {
   // 1. Find workspace root and main worktree
   const { workspaceRoot, mainWorktree, bareRepo } = await requireWorkspace();
@@ -36,7 +37,13 @@ export async function cancelProject(
     );
   }
 
-  // 4. Remove the worktree
+  // 4. Confirm cancellation
+  await confirmOrExit(
+    `Cancel project '${projectName}'? This will permanently delete the worktree, branch, and project config.`,
+    options?.yes ?? false,
+  );
+
+  // 5. Remove the worktree
   console.log(`Cancelling project '${projectName}'...`);
   try {
     if (options?.force) {

--- a/src/commands/prune.ts
+++ b/src/commands/prune.ts
@@ -6,12 +6,13 @@ import path from "node:path";
 import { readdir, unlink } from "node:fs/promises";
 import { requireWorkspace } from "../utils/workspace.js";
 import { gitCommit } from "../utils/git.js";
+import { confirmOrExit } from "../utils/prompts.js";
 
 /**
  * Prune rejected ideas by deleting them
- * grind prune ideas
+ * grind prune ideas [-y]
  */
-export async function pruneIdeas(): Promise<void> {
+export async function pruneIdeas(options?: { yes?: boolean }): Promise<void> {
   const { mainWorktree } = await requireWorkspace();
 
   const ideasDir = path.join(mainWorktree, "ideas");
@@ -27,8 +28,19 @@ export async function pruneIdeas(): Promise<void> {
     return;
   }
 
-  // Delete each rejected file
+  // List what will be pruned
   console.log(`Found ${rejectedFiles.length} rejected idea(s) to prune:`);
+  for (const file of rejectedFiles) {
+    console.log(`  - ${file}`);
+  }
+
+  // Confirm before deleting
+  await confirmOrExit(
+    `Delete ${rejectedFiles.length} rejected idea(s)?`,
+    options?.yes ?? false,
+  );
+
+  // Delete each rejected file
   for (const file of rejectedFiles) {
     const filepath = path.join(ideasDir, file);
     await unlink(filepath);

--- a/src/commands/publish-project.ts
+++ b/src/commands/publish-project.ts
@@ -9,15 +9,16 @@ import { fileExists } from "../utils/files.js";
 import { getDefaultBranch, hasUncommittedChanges } from "../utils/git.js";
 import { readGrindConfig, readProjectConfig, writeProjectConfig } from "../utils/config.js";
 import { getCurrentTimestamp } from "../utils/time.js";
+import { confirmOrExit } from "../utils/prompts.js";
 import { GrindUserError, GrindSystemError } from "../utils/errors.js";
 
 /**
  * Publish a project by merging to main
- * grind publish project <name> [-d] [-D] [-u <url>]
+ * grind publish project <name> [-d] [-D] [-u <url>] [-y]
  */
 export async function publishProject(
   projectName: string,
-  options?: { deleteWorktree?: boolean; deleteBranch?: boolean; url?: string }
+  options?: { deleteWorktree?: boolean; deleteBranch?: boolean; url?: string; yes?: boolean }
 ): Promise<void> {
   // 1. Find workspace root and main worktree
   const { workspaceRoot, mainWorktree, bareRepo } = await requireWorkspace();
@@ -78,6 +79,13 @@ export async function publishProject(
   // 8. If -d or -D flag: remove worktree (and optionally branch)
   if (options?.deleteWorktree || options?.deleteBranch) {
     console.log("\nCleaning up worktree...");
+
+    let deletePrompt = `Delete worktree for '${projectName}'?`;
+    if (options?.deleteBranch) {
+      deletePrompt += " This will also delete the branch.";
+    }
+    await confirmOrExit(deletePrompt, options?.yes ?? false);
+
     await $`git -C ${bareRepo} worktree remove ${worktreePath}`.quiet();
     console.log(`  - Removed worktree: ${worktreePath}`);
 

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -11,7 +11,7 @@ import { GrindUserError } from "../utils/errors.js";
 
 export async function save(
   projectName: string,
-  options?: { quiet?: boolean; time?: string },
+  options?: { quiet?: boolean; time?: string; yes?: boolean },
 ): Promise<void> {
   const { workspaceRoot } = await requireWorkspace();
   const worktreePath = path.join(workspaceRoot, projectName);
@@ -63,7 +63,9 @@ export async function save(
   if (await hasUncommittedChanges(worktreePath)) {
     console.log(`Committing changes...`);
 
-    if (options?.quiet) {
+    const autoCommit = options?.quiet || options?.yes;
+
+    if (autoCommit) {
       const timestamp = new Date().toLocaleString();
       const commitMessage = roundedHours
         ? `Work Session on ${timestamp}: ${roundedHours}h\n=== WARNING: May contain unfinished work. ===`

--- a/src/index.ts
+++ b/src/index.ts
@@ -259,22 +259,26 @@ program
     await openCode(project);
   });
 
-// grind save "project" [-q] [-t <hours>]
+// grind save "project" [-q] [-y] [-t <hours>]
 program
   .command("save <project>")
   .description("Save work on a project (stops timer, commits changes)")
   .option("-q, --quiet", "Use auto-generated commit message (quick save)")
+  .option("-y, --yes", "Skip interactive commit (same as --quiet)")
   .option(
     "-t, --time <hours>",
     "Backfill: set session end time to start + N hours",
   )
   .action(
-    async (project: string, options: { quiet?: boolean; time?: string }) => {
+    async (
+      project: string,
+      options: { quiet?: boolean; yes?: boolean; time?: string },
+    ) => {
       await save(project, options);
     },
   );
 
-// grind publish <name> [-d] [-D] [-u <url>]
+// grind publish <name> [-d] [-D] [-u <url>] [-y]
 program
   .command("publish <name>")
   .description(
@@ -283,6 +287,7 @@ program
   .option("-d, --delete-worktree", "Delete worktree after merging")
   .option("-D, --delete-branch", "Delete worktree and branch after merging")
   .option("-u, --url <url>", "URL where this project was published")
+  .option("-y, --yes", "Skip confirmation before deleting worktree")
   .action(
     async (
       name: string,
@@ -290,22 +295,26 @@ program
         deleteWorktree?: boolean;
         deleteBranch?: boolean;
         url?: string;
+        yes?: boolean;
       },
     ) => {
       await publishProject(name, options);
     },
   );
 
-// grind cancel <name> [--force]
+// grind cancel <name> [--force] [-y]
 program
   .command("cancel <name>")
   .description(
     "Cancel (abandon) a project — removes worktree, branch, and config",
   )
   .option("-f, --force", "Force removal even with uncommitted changes")
-  .action(async (name: string, options: { force?: boolean }) => {
-    await cancelProject(name, options);
-  });
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(
+    async (name: string, options: { force?: boolean; yes?: boolean }) => {
+      await cancelProject(name, options);
+    },
+  );
 
 // grind promote <name>
 program
@@ -335,8 +344,9 @@ const pruneCmd = program
 pruneCmd
   .command("ideas")
   .description("Delete all rejected ideas (files starting with 'rejected-')")
-  .action(async () => {
-    await pruneIdeas();
+  .option("-y, --yes", "Skip confirmation prompt")
+  .action(async (options: { yes?: boolean }) => {
+    await pruneIdeas(options);
   });
 
 // grind invoice <project>

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -1,0 +1,19 @@
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+
+export async function confirmOrExit(prompt: string, skip: boolean): Promise<void> {
+  if (skip) return;
+
+  const rl = createInterface({
+    input: stdin,
+    output: stdout,
+  });
+
+  const answer = await rl.question(`${prompt} (y/N) `);
+  rl.close();
+
+  if (answer.toLowerCase() !== "y" && answer.toLowerCase() !== "yes") {
+    console.log("Aborted.");
+    process.exit(0);
+  }
+}

--- a/tests/commands/cancel.test.ts
+++ b/tests/commands/cancel.test.ts
@@ -1,0 +1,82 @@
+import { cancelProject } from "../../src/commands/cancel.js";
+import { GrindUserError } from "../../src/utils/errors.js";
+
+jest.mock("bun");
+jest.mock("node:fs/promises");
+jest.mock("../../src/utils/workspace.js", () => ({
+  requireWorkspace: jest.fn().mockResolvedValue({
+    workspaceRoot: "/home/user/workspace",
+    mainWorktree: "/home/user/workspace/grind",
+    bareRepo: "/home/user/workspace/.grind.repo.git",
+  }),
+}));
+jest.mock("../../src/utils/files.js", () => ({
+  fileExists: jest.fn().mockImplementation((p: string) =>
+    Promise.resolve(p.includes("test-project")),
+  ),
+}));
+jest.mock("../../src/utils/git.js", () => ({
+  gitCommit: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock("../../src/utils/prompts.js");
+
+import { confirmOrExit } from "../../src/utils/prompts.js";
+import { fileExists } from "../../src/utils/files.js";
+import * as fs from "node:fs/promises";
+
+const mock$ = jest.requireMock("bun").$ as jest.Mock;
+
+describe("cancelProject", () => {
+  const projectName = "test-project";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(process, "exit").mockImplementation((() => {}) as () => never);
+
+    mock$.mockImplementation(() => ({
+      nothrow: jest.fn().mockResolvedValue({
+        stdout: Buffer.from(""),
+        exitCode: 0,
+      }),
+      quiet: jest.fn().mockResolvedValue({
+        stdout: Buffer.from(""),
+        exitCode: 0,
+      }),
+    }));
+
+    (fs.rm as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it("should skip confirmation when yes flag is true", async () => {
+    await cancelProject(projectName, { yes: true });
+    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+  });
+
+  it("should call confirmOrExit when yes flag is false", async () => {
+    (confirmOrExit as jest.Mock).mockResolvedValue(undefined);
+    await cancelProject(projectName, { yes: false });
+    expect(confirmOrExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call confirmOrExit with correct prompt when no flag", async () => {
+    (confirmOrExit as jest.Mock).mockResolvedValue(undefined);
+    await cancelProject(projectName);
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      expect.stringContaining("Cancel project 'test-project'?"),
+      false,
+    );
+  });
+
+  it("should still use --force for worktree removal when -f is passed", async () => {
+    (confirmOrExit as jest.Mock).mockResolvedValue(undefined);
+    await cancelProject(projectName, { force: true, yes: true });
+    expect(mock$).toHaveBeenCalled();
+  });
+
+  it("should throw when project worktree does not exist", async () => {
+    (fileExists as jest.Mock).mockResolvedValue(false);
+    await expect(cancelProject("nonexistent")).rejects.toThrow(GrindUserError);
+  });
+});

--- a/tests/commands/prune.test.ts
+++ b/tests/commands/prune.test.ts
@@ -1,0 +1,61 @@
+import { pruneIdeas } from "../../src/commands/prune.js";
+
+jest.mock("node:fs/promises");
+jest.mock("../../src/utils/workspace.js", () => ({
+  requireWorkspace: jest.fn().mockResolvedValue({
+    mainWorktree: "/home/user/workspace/grind",
+  }),
+}));
+jest.mock("../../src/utils/git.js", () => ({
+  gitCommit: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock("../../src/utils/prompts.js");
+
+import * as fs from "node:fs/promises";
+import { confirmOrExit } from "../../src/utils/prompts.js";
+
+describe("pruneIdeas", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    (fs.readdir as jest.Mock).mockResolvedValue([
+      "rejected-wrong.md",
+      "rejected-bad.md",
+      "good-idea.md",
+    ]);
+    (fs.unlink as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it("should skip confirmation when yes flag is true", async () => {
+    await pruneIdeas({ yes: true });
+    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+  });
+
+  it("should call confirmOrExit when yes flag is false", async () => {
+    (confirmOrExit as jest.Mock).mockResolvedValue(undefined);
+    await pruneIdeas({ yes: false });
+    expect(confirmOrExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call confirmOrExit with correct prompt when no flag", async () => {
+    (confirmOrExit as jest.Mock).mockResolvedValue(undefined);
+    await pruneIdeas();
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Delete 2 rejected idea(s)?",
+      false,
+    );
+  });
+
+  it("should delete files and commit when confirmed", async () => {
+    (confirmOrExit as jest.Mock).mockResolvedValue(undefined);
+    await pruneIdeas();
+    expect(fs.unlink).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not proceed when no rejected ideas exist", async () => {
+    (fs.readdir as jest.Mock).mockResolvedValue(["good-idea.md"]);
+    await pruneIdeas();
+    expect(confirmOrExit).not.toHaveBeenCalled();
+    expect(fs.unlink).not.toHaveBeenCalled();
+  });
+});

--- a/tests/commands/publish-project.test.ts
+++ b/tests/commands/publish-project.test.ts
@@ -1,0 +1,94 @@
+import { publishProject } from "../../src/commands/publish-project.js";
+import { GrindUserError } from "../../src/utils/errors.js";
+
+jest.mock("bun");
+jest.mock("node:fs/promises");
+jest.mock("../../src/utils/workspace.js", () => ({
+  requireWorkspace: jest.fn().mockResolvedValue({
+    workspaceRoot: "/home/user/workspace",
+    mainWorktree: "/home/user/workspace/grind",
+    bareRepo: "/home/user/workspace/.grind.repo.git",
+  }),
+}));
+jest.mock("../../src/utils/files.js", () => ({
+  fileExists: jest.fn().mockResolvedValue(true),
+}));
+jest.mock("../../src/utils/git.js", () => ({
+  getDefaultBranch: jest.fn().mockResolvedValue("main"),
+  hasUncommittedChanges: jest.fn().mockResolvedValue(false),
+}));
+jest.mock("../../src/utils/config.js", () => ({
+  readGrindConfig: jest.fn().mockResolvedValue({}),
+  readProjectConfig: jest.fn().mockResolvedValue(null),
+  writeProjectConfig: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock("../../src/utils/prompts.js");
+
+import { confirmOrExit } from "../../src/utils/prompts.js";
+
+const mock$ = jest.requireMock("bun").$ as jest.Mock;
+
+describe("publishProject", () => {
+  const projectName = "test-project";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    mock$.mockImplementation(() => ({
+      nothrow: jest.fn().mockResolvedValue({
+        stdout: Buffer.from(""),
+        exitCode: 0,
+      }),
+      quiet: jest.fn().mockResolvedValue({
+        stdout: Buffer.from(""),
+        exitCode: 0,
+      }),
+    }));
+  });
+
+  it("should skip confirmation on delete when yes flag is true", async () => {
+    await publishProject(projectName, {
+      deleteWorktree: true,
+      yes: true,
+    });
+    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+  });
+
+  it("should call confirmOrExit on delete when yes flag is false", async () => {
+    (confirmOrExit as jest.Mock).mockResolvedValue(undefined);
+    await publishProject(projectName, {
+      deleteWorktree: true,
+      yes: false,
+    });
+    expect(confirmOrExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call confirmOrExit with correct delete prompt", async () => {
+    (confirmOrExit as jest.Mock).mockResolvedValue(undefined);
+    await publishProject(projectName, {
+      deleteWorktree: true,
+    });
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      expect.stringContaining("Delete worktree for 'test-project'?"),
+      false,
+    );
+  });
+
+  it("should not prompt for confirmation when not deleting", async () => {
+    await publishProject(projectName);
+    expect(confirmOrExit).not.toHaveBeenCalled();
+  });
+
+  it("should mention branch deletion in prompt when -D is used", async () => {
+    (confirmOrExit as jest.Mock).mockResolvedValue(undefined);
+    await publishProject(projectName, {
+      deleteBranch: true,
+    });
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      expect.stringContaining("also delete the branch"),
+      false,
+    );
+  });
+});

--- a/tests/commands/save.test.ts
+++ b/tests/commands/save.test.ts
@@ -1,0 +1,56 @@
+import { save } from "../../src/commands/save.js";
+
+jest.mock("../../src/utils/workspace.js", () => ({
+  requireWorkspace: jest.fn().mockResolvedValue({
+    workspaceRoot: "/home/user/workspace",
+  }),
+}));
+jest.mock("../../src/utils/config.js", () => ({
+  readProjectConfig: jest
+    .fn()
+    .mockResolvedValue({
+      name: "test-project",
+      idea: "Test",
+      time: [],
+      billing: { roundTo: "quarter-hour", rate: 150 },
+    }),
+  writeProjectConfig: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock("../../src/utils/session.js", () => ({
+  getActiveSession: jest.fn().mockReturnValue(null),
+  endSession: jest.fn().mockReturnValue(undefined),
+}));
+jest.mock("../../src/utils/git.js", () => ({
+  gitCommit: jest.fn().mockResolvedValue(undefined),
+  gitCommitInteractive: jest.fn().mockResolvedValue(undefined),
+  hasUncommittedChanges: jest.fn().mockResolvedValue(true),
+}));
+jest.mock("../../src/utils/prompts.js");
+
+import { confirmOrExit } from "../../src/utils/prompts.js";
+import { gitCommitInteractive, gitCommit } from "../../src/utils/git.js";
+
+describe("save", () => {
+  const projectName = "test-project";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("should auto-commit with generated message when yes flag is true", async () => {
+    await save(projectName, { yes: true });
+    expect(gitCommitInteractive).not.toHaveBeenCalled();
+    expect(gitCommit).toHaveBeenCalledTimes(1);
+    expect(gitCommit).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining("Save"),
+    );
+  });
+
+  it("should open interactive commit when no quiet or yes flag", async () => {
+    await save(projectName);
+    expect(gitCommitInteractive).toHaveBeenCalledTimes(1);
+    expect(gitCommit).not.toHaveBeenCalled();
+  });
+});

--- a/tests/utils/prompts.test.ts
+++ b/tests/utils/prompts.test.ts
@@ -1,0 +1,67 @@
+import { confirmOrExit } from "../../src/utils/prompts.js";
+
+jest.mock("node:readline/promises", () => ({
+  createInterface: jest.fn(),
+}));
+
+jest.spyOn(process, "exit").mockImplementation((() => {}) as (code?: number) => never);
+
+import { createInterface } from "node:readline/promises";
+
+describe("confirmOrExit", () => {
+  let mockRl: { question: jest.Mock; close: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRl = {
+      question: jest.fn(),
+      close: jest.fn(),
+    };
+    (createInterface as jest.Mock).mockReturnValue(mockRl);
+  });
+
+  it("should skip prompt and return when skip is true", async () => {
+    await confirmOrExit("Proceed?", true);
+    expect(createInterface).not.toHaveBeenCalled();
+  });
+
+  it("should create readline interface when skip is false", async () => {
+    mockRl.question.mockResolvedValue("y");
+    await confirmOrExit("Proceed?", false);
+    expect(createInterface).toHaveBeenCalledTimes(1);
+  });
+
+  it("should prompt with the correct message", async () => {
+    mockRl.question.mockResolvedValue("y");
+    await confirmOrExit("Delete 3 files?", false);
+    expect(mockRl.question).toHaveBeenCalledWith("Delete 3 files? (y/N) ");
+  });
+
+  it("should proceed when answer is y", async () => {
+    mockRl.question.mockResolvedValue("y");
+    await expect(confirmOrExit("Proceed?", false)).resolves.toBeUndefined();
+  });
+
+  it("should proceed when answer is yes", async () => {
+    mockRl.question.mockResolvedValue("yes");
+    await expect(confirmOrExit("Proceed?", false)).resolves.toBeUndefined();
+  });
+
+  it("should exit when answer is n", async () => {
+    mockRl.question.mockResolvedValue("n");
+    await confirmOrExit("Proceed?", false);
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
+  it("should exit when answer is empty", async () => {
+    mockRl.question.mockResolvedValue("");
+    await confirmOrExit("Proceed?", false);
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+
+  it("should close readline interface after getting answer", async () => {
+    mockRl.question.mockResolvedValue("y");
+    await confirmOrExit("Proceed?", false);
+    expect(mockRl.close).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #34

## Changes

- **New** `src/utils/prompts.ts`: `confirmOrExit(prompt, skip)` utility — prints a y/N prompt and exits unless confirmed. Pass `skip=true` to bypass (used by `-y`/\`\`\`--yes\`\`\` flags).
- **prune ideas**: Added confirmation prompt before deleting rejected files. New `-y`/`--yes` flag skips the prompt.
- **cancel \<project\>**: Added confirmation prompt before removing worktree/branch/config. `-y` skips it. `-f` still force-removes independently.
- **publish \<project\>**: Added confirmation prompt before worktree deletion when `-d`/`-D` is used. Prompt mentions branch deletion when `-D`. `-y` skips.
- **save \<project\>**: Added `-y`/`--yes` flag as an alias for `--quiet` — auto-commits with generated message.
- **Tests**: New test files for prompts utility and each modified command (TDD: Red/Green/Refactor).
- **Documentation**: Updated CLAUDE.md to document the prompts utility.

## Verification

- 47 tests passing across 9 test suites
- `tsc --noEmit` clean