### PR TITLE
fix: exclude main branch commits from project commit count

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -99,7 +99,7 @@ export async function gitAddWorktree(
  */
 export async function getCommitCount(repoPath: string, branch: string): Promise<number> {
   try {
-    const result = await $`git -C ${repoPath} rev-list --count ${branch}`.quiet();
+    const result = await $`git -C ${repoPath} rev-list --count ${branch} --not main`.quiet();
     return parseInt(result.stdout.toString().trim(), 10);
   } catch {
     return 0;


### PR DESCRIPTION
`getCommitCount` was using `git rev-list --count <branch>` which counts all commits on the branch including those inherited from `main`. This caused `grind status` to show hundreds of commits for projects that had never been worked on.

Now uses `--not main` to only count project-specific commits, matching the existing pattern in `getFirstCommitDate`.

Fixes #51